### PR TITLE
Support Timestamp/ULID model types in api.from_timestamp.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -170,6 +170,28 @@ def test_from_timestamp_bytes_returns_ulid_instance(buffer_type, valid_bytes_48)
     assert instance.timestamp().bytes() == value
 
 
+def test_from_timestamp_timestamp_returns_ulid_instance(valid_bytes_48):
+    """
+    Assert that :func:`~ulid.api.from_timestamp` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as a :class:`~ulid.ulid.Timestamp`.
+    """
+    value = ulid.Timestamp(valid_bytes_48)
+    instance = api.from_timestamp(value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp() == value
+
+
+def test_from_timestamp_ulid_returns_ulid_instance(valid_bytes_128):
+    """
+    Assert that :func:`~ulid.api.from_timestamp` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as a :class:`~ulid.ulid.ULID`.
+    """
+    value = ulid.ULID(valid_bytes_128)
+    instance = api.from_timestamp(value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp() == value.timestamp()
+
+
 def test_from_timestamp_with_unsupported_type_raises(unsupported_type):
     """
     Assert that :func:`~ulid.api.from_timestamp` raises a :class:`~ValueError` when given

--- a/ulid/api.py
+++ b/ulid/api.py
@@ -7,12 +7,24 @@
 import datetime
 import os
 import time
+import typing
 import uuid
 
 from . import base32, hints, ulid
 
 
 __all__ = ['new', 'from_bytes', 'from_int', 'from_str', 'from_uuid', 'from_timestamp', 'from_randomness']
+
+
+#: Type hint that defines multiple primitive types that can represent
+#: a Unix timestamp in seconds.
+TimestampPrimitive = typing.Union[int, float, str, bytes, bytearray, memoryview,
+                                  datetime.datetime, ulid.Timestamp, ulid.ULID]
+
+
+#: Type hint that defines multiple primitive types that can represent
+#: randomness.
+RandomnessPrimitive = typing.Union[int, float, str, bytes, bytearray, memoryview]
 
 
 def new() -> ulid.ULID:
@@ -90,7 +102,7 @@ def from_uuid(value: uuid.UUID) -> ulid.ULID:
     return ulid.ULID(value.bytes)
 
 
-def from_timestamp(timestamp: hints.TimestampPrimitive) -> ulid.ULID:
+def from_timestamp(timestamp: TimestampPrimitive) -> ulid.ULID:
     """
     Create a new :class:`~ulid.ulid.ULID` instance using the given :class:`~int`, :class:`~float`,
     :class:`~str`, :class:`~bytes`, :class:`~bytearray`, or :class`~memoryview` value that
@@ -126,7 +138,7 @@ def from_timestamp(timestamp: hints.TimestampPrimitive) -> ulid.ULID:
     return ulid.ULID(timestamp + randomness)
 
 
-def from_randomness(randomness: hints.RandomnessPrimitive) -> ulid.ULID:
+def from_randomness(randomness: RandomnessPrimitive) -> ulid.ULID:
     """
     Create a new :class:`~ulid.ulid.ULID` instance using the given :class:`~int`, :class:`~float`,
     :class:`~str`, :class:`~bytes`, :class:`~bytearray`, or :class`~memoryview` value that

--- a/ulid/api.py
+++ b/ulid/api.py
@@ -104,13 +104,22 @@ def from_uuid(value: uuid.UUID) -> ulid.ULID:
 
 def from_timestamp(timestamp: TimestampPrimitive) -> ulid.ULID:
     """
-    Create a new :class:`~ulid.ulid.ULID` instance using the given :class:`~int`, :class:`~float`,
-    :class:`~str`, :class:`~bytes`, :class:`~bytearray`, or :class`~memoryview` value that
-    represents Unix timestamp in seconds.
+    Create a new :class:`~ulid.ulid.ULID` instance using a timestamp value of a supported type.
+
+    The following types are supported for timestamp values:
+
+    * :class:`~datetime.datetime`
+    * :class:`~int`
+    * :class:`~float`
+    * :class:`~str`
+    * :class:`~memoryview`
+    * :class:`~ulid.ulid.Timestamp`
+    * :class:`~ulid.ulid.ULID`
+    * :class:`~ulid.ulid.bytes`
+    * :class:`~ulid.ulid.bytearray`
 
     :param timestamp: Unix timestamp in seconds
-    :type timestamp: :class:`~int`, :class:`~float`, :class:`~str`,
-        :class:`~bytes`, :class:`~bytearray`, :class:`~memoryview`, or :class:`~datetime.datetime`
+    :type timestamp: See docstring for types
     :return: ULID using given timestamp and new randomness
     :rtype: :class:`~ulid.ulid.ULID`
     :raises ValueError: when the value is an unsupported type
@@ -125,10 +134,14 @@ def from_timestamp(timestamp: TimestampPrimitive) -> ulid.ULID:
         timestamp = base32.decode_timestamp(timestamp)
     elif isinstance(timestamp, memoryview):
         timestamp = timestamp.tobytes()
+    elif isinstance(timestamp, ulid.Timestamp):
+        timestamp = timestamp.bytes()
+    elif isinstance(timestamp, ulid.ULID):
+        timestamp = timestamp.timestamp().bytes()
 
     if not isinstance(timestamp, (bytes, bytearray)):
-        raise ValueError('Expected int, float, str, bytes, '
-                         'bytearray, or memoryview; got {}'.format(type(timestamp).__name__))
+        raise ValueError('Expected datetime, int, float, str, memoryview, Timestamp, ULID, '
+                         'bytes, or bytearray; got {}'.format(type(timestamp).__name__))
 
     length = len(timestamp)
     if length != 6:

--- a/ulid/hints.py
+++ b/ulid/hints.py
@@ -2,22 +2,11 @@
     ulid/hints
     ~~~~~~~~~~
 
-    Contains type hint definitions for the package.
+    Contains type hint definitions across modules in the package.
 """
-import datetime
 import typing
 
 
 #: Type hint that defines multiple types that implement the buffer protocol
 #: that can encoded into a Base32 string.
 Buffer = typing.Union[bytes, bytearray, memoryview]
-
-
-#: Type hint that defines multiple primitive types that can represent
-#: a Unix timestamp in seconds.
-TimestampPrimitive = typing.Union[int, float, str, bytes, bytearray, memoryview, datetime.datetime]
-
-
-#: Type hint that defines multiple primitive types that can represent
-#: randomness.
-RandomnessPrimitive = typing.Union[int, float, str, bytes, bytearray, memoryview]


### PR DESCRIPTION
Addresses #5 