### PR TITLE
Refactor model representation methods to be properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ A `MemoryView` provides the `str`, `int`, and `bytes` methods for changing any v
 <ULID('01BJQMF54D093DXEAWZ6JYRPAQ')>
 >>> u.timestamp()
 <Timestamp('01BJQMF54D')>
->>> u.timestamp().int()
+>>> u.timestamp().int
 1497589322893
->>> u.timestamp().bytes()
+>>> u.timestamp().bytes
 b'\x01\\\xafG\x94\x8d'
->>> u.timestamp().datetime()
+>>> u.timestamp().datetime
 datetime.datetime(2017, 6, 16, 5, 2, 2, 893000)
->>> u.randomness().bytes()
+>>> u.randomness().bytes
 b'\x02F\xde\xb9\\\xf9\xa5\xecYW'
->>> u.bytes()[6:] == u.randomness().bytes()
+>>> u.bytes[6:] == u.randomness().bytes
 True
->>> u.str()
+>>> u.str
 '01BJQMF54D093DXEAWZ6JYRPAQ'
->>> u.int()
+>>> u.int
 1810474399624548315999517391436142935
 ```
 
@@ -133,7 +133,7 @@ True
 >>> u3 = ulid.from_timestamp(datetime.datetime(2039, 1, 1))
 >>> u1 < u2 < u3
 True
->>> [u.timestamp().datetime() for u in sorted([u2, u3, u1])]
+>>> [u.timestamp().datetime for u in sorted([u2, u3, u1])]
 [datetime.datetime(2017, 6, 16, 5, 7, 14, 847000), datetime.datetime(2017, 6, 16, 5, 7, 26, 775000), datetime.datetime(2039, 1, 1, 8, 0)]
 ```
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -49,7 +49,7 @@ def test_from_bytes_returns_ulid_instance(buffer_type, valid_bytes_128):
     value = buffer_type(valid_bytes_128)
     instance = api.from_bytes(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.bytes() == valid_bytes_128
+    assert instance.bytes == valid_bytes_128
 
 
 def test_from_bytes_raises_when_not_128_bits(buffer_type, invalid_bytes_128):
@@ -70,7 +70,7 @@ def test_from_int_returns_ulid_instance(valid_bytes_128):
     value = int.from_bytes(valid_bytes_128, byteorder='big')
     instance = api.from_int(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.bytes() == valid_bytes_128
+    assert instance.bytes == valid_bytes_128
 
 
 def test_from_int_raises_when_not_128_bits(invalid_bytes_128):
@@ -91,7 +91,7 @@ def test_from_str_returns_ulid_instance(valid_bytes_128):
     value = base32.encode(valid_bytes_128)
     instance = api.from_str(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.bytes() == valid_bytes_128
+    assert instance.bytes == valid_bytes_128
 
 
 def test_from_str_raises_when_not_128_bits(valid_bytes_48):
@@ -112,7 +112,7 @@ def test_from_uuid_returns_ulid_instance():
     value = uuid.uuid4()
     instance = api.from_uuid(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.bytes() == value.bytes
+    assert instance.bytes == value.bytes
 
 
 def test_from_timestamp_datetime_returns_ulid_instance():
@@ -123,7 +123,7 @@ def test_from_timestamp_datetime_returns_ulid_instance():
     value = datetime.datetime.now()
     instance = api.from_timestamp(value)
     assert isinstance(instance, ulid.ULID)
-    assert int(instance.timestamp().timestamp()) == int(value.timestamp())
+    assert int(instance.timestamp().timestamp) == int(value.timestamp())
 
 
 def test_from_timestamp_int_returns_ulid_instance():
@@ -134,7 +134,7 @@ def test_from_timestamp_int_returns_ulid_instance():
     value = int(time.time())
     instance = api.from_timestamp(value)
     assert isinstance(instance, ulid.ULID)
-    assert int(instance.timestamp().timestamp()) == value
+    assert int(instance.timestamp().timestamp) == value
 
 
 def test_from_timestamp_float_returns_ulid_instance():
@@ -145,7 +145,7 @@ def test_from_timestamp_float_returns_ulid_instance():
     value = float(time.time())
     instance = api.from_timestamp(value)
     assert isinstance(instance, ulid.ULID)
-    assert int(instance.timestamp().timestamp()) == int(value)
+    assert int(instance.timestamp().timestamp) == int(value)
 
 
 def test_from_timestamp_str_returns_ulid_instance(valid_bytes_48):
@@ -156,7 +156,7 @@ def test_from_timestamp_str_returns_ulid_instance(valid_bytes_48):
     value = base32.encode_timestamp(valid_bytes_48)
     instance = api.from_timestamp(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.timestamp().str() == value
+    assert instance.timestamp().str == value
 
 
 def test_from_timestamp_bytes_returns_ulid_instance(buffer_type, valid_bytes_48):
@@ -167,7 +167,7 @@ def test_from_timestamp_bytes_returns_ulid_instance(buffer_type, valid_bytes_48)
     value = buffer_type(valid_bytes_48)
     instance = api.from_timestamp(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.timestamp().bytes() == value
+    assert instance.timestamp().bytes == value
 
 
 def test_from_timestamp_timestamp_returns_ulid_instance(valid_bytes_48):
@@ -218,7 +218,7 @@ def test_from_randomness_int_returns_ulid_instance(valid_bytes_80):
     value = int.from_bytes(valid_bytes_80, byteorder='big')
     instance = api.from_randomness(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.randomness().int() == value
+    assert instance.randomness().int == value
 
 
 def test_from_randomness_float_returns_ulid_instance(valid_bytes_80):
@@ -229,7 +229,7 @@ def test_from_randomness_float_returns_ulid_instance(valid_bytes_80):
     value = float(int.from_bytes(valid_bytes_80, byteorder='big'))
     instance = api.from_randomness(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.randomness().int() == int(value)
+    assert instance.randomness().int == int(value)
 
 
 def test_from_randomness_str_returns_ulid_instance(valid_bytes_80):
@@ -240,7 +240,7 @@ def test_from_randomness_str_returns_ulid_instance(valid_bytes_80):
     value = base32.encode_randomness(valid_bytes_80)
     instance = api.from_randomness(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.randomness().str() == value
+    assert instance.randomness().str == value
 
 
 def test_from_randomness_bytes_returns_ulid_instance(buffer_type, valid_bytes_80):
@@ -251,7 +251,7 @@ def test_from_randomness_bytes_returns_ulid_instance(buffer_type, valid_bytes_80
     value = buffer_type(valid_bytes_80)
     instance = api.from_randomness(value)
     assert isinstance(instance, ulid.ULID)
-    assert instance.randomness().bytes() == value
+    assert instance.randomness().bytes == value
 
 
 def test_from_randomness_randomness_returns_ulid_instance(valid_bytes_80):

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -144,7 +144,7 @@ def test_memoryview_supports_str(valid_bytes_128):
     result of the :meth:`~ulid.ulid.MemoryView.str` method.
     """
     mv = ulid.MemoryView(valid_bytes_128)
-    assert str(mv) == mv.str()
+    assert str(mv) == mv.str
 
 
 def test_memoryview_supports_int(valid_bytes_128):
@@ -153,7 +153,7 @@ def test_memoryview_supports_int(valid_bytes_128):
     result of the :meth:`~ulid.ulid.MemoryView.int` method.
     """
     mv = ulid.MemoryView(valid_bytes_128)
-    assert int(mv) == mv.int()
+    assert int(mv) == mv.int
 
 
 def test_memoryview_defines_hash(valid_bytes_128):
@@ -171,7 +171,7 @@ def test_timestamp_coverts_bytes_to_unix_time_seconds():
     """
     now_ms = int(time.time()) * 1000
     timestamp = ulid.Timestamp(now_ms.to_bytes(6, byteorder='big'))
-    assert timestamp.timestamp() == now_ms / 1000.0
+    assert timestamp.timestamp == now_ms / 1000.0
 
 
 def test_timestamp_converts_to_datetime():
@@ -181,7 +181,7 @@ def test_timestamp_converts_to_datetime():
     """
     now_ms = int(time.time()) * 1000
     timestamp = ulid.Timestamp(now_ms.to_bytes(6, byteorder='big'))
-    assert timestamp.datetime() == datetime.datetime.utcfromtimestamp(now_ms / 1000.0)
+    assert timestamp.datetime == datetime.datetime.utcfromtimestamp(now_ms / 1000.0)
 
 
 def test_ulid_timestamp_returns_instance(valid_bytes_128):
@@ -197,7 +197,7 @@ def test_ulid_timestamp_is_first_48_bits(valid_bytes_128):
     is populated with the first 48 bits of the ULID.
     """
     timestamp = ulid.ULID(valid_bytes_128).timestamp()
-    assert timestamp.bytes() == valid_bytes_128[:6]
+    assert timestamp.bytes == valid_bytes_128[:6]
 
 
 def test_ulid_randomness_returns_instance(valid_bytes_128):
@@ -213,11 +213,11 @@ def test_ulid_randomness_is_first_48_bits(valid_bytes_128):
     is populated with the last 80 bits of the ULID.
     """
     randomness = ulid.ULID(valid_bytes_128).randomness()
-    assert randomness.bytes() == valid_bytes_128[6:]
+    assert randomness.bytes == valid_bytes_128[6:]
 
 
 def test_ulid_uuid_returns_instance(valid_bytes_128):
     """
     Assert that :func:`~ulid.ulid.ULID.uuid` returns a :class:`~uuid.UUID` instance.
     """
-    assert isinstance(ulid.ULID(valid_bytes_128).uuid(), uuid.UUID)
+    assert isinstance(ulid.ULID(valid_bytes_128).uuid, uuid.UUID)

--- a/ulid/api.py
+++ b/ulid/api.py
@@ -136,9 +136,9 @@ def from_timestamp(timestamp: TimestampPrimitive) -> ulid.ULID:
     elif isinstance(timestamp, memoryview):
         timestamp = timestamp.tobytes()
     elif isinstance(timestamp, ulid.Timestamp):
-        timestamp = timestamp.bytes()
+        timestamp = timestamp.bytes
     elif isinstance(timestamp, ulid.ULID):
-        timestamp = timestamp.timestamp().bytes()
+        timestamp = timestamp.timestamp().bytes
 
     if not isinstance(timestamp, (bytes, bytearray)):
         raise ValueError('Expected datetime, int, float, str, memoryview, Timestamp, ULID, '
@@ -182,9 +182,9 @@ def from_randomness(randomness: RandomnessPrimitive) -> ulid.ULID:
     elif isinstance(randomness, memoryview):
         randomness = randomness.tobytes()
     elif isinstance(randomness, ulid.Randomness):
-        randomness = randomness.bytes()
+        randomness = randomness.bytes
     elif isinstance(randomness, ulid.ULID):
-        randomness = randomness.randomness().bytes()
+        randomness = randomness.randomness().bytes
 
     if not isinstance(randomness, (bytes, bytearray)):
         raise ValueError('Expected int, float, str, memoryview, Randomness, ULID, '

--- a/ulid/ulid.py
+++ b/ulid/ulid.py
@@ -30,9 +30,9 @@ class MemoryView:
         if isinstance(other, (bytes, bytearray, memoryview)):
             return self.memory == other
         if isinstance(other, int):
-            return self.int() == other
+            return self.int == other
         if isinstance(other, str):
-            return self.str() == other
+            return self.str == other
         return NotImplemented
 
     def __ne__(self, other):
@@ -41,75 +41,76 @@ class MemoryView:
         if isinstance(other, (bytes, bytearray, memoryview)):
             return self.memory != other
         if isinstance(other, int):
-            return self.int() != other
+            return self.int != other
         if isinstance(other, str):
-            return self.str() != other
+            return self.str != other
         return NotImplemented
 
     def __lt__(self, other):
         if isinstance(other, MemoryView):
-            return self.int() < other.int()
+            return self.int < other.int
         if isinstance(other, (bytes, bytearray)):
-            return self.bytes() < other
+            return self.bytes < other
         if isinstance(other, memoryview):
-            return self.bytes() < other.tobytes()
+            return self.bytes < other.tobytes()
         if isinstance(other, int):
-            return self.int() < other
+            return self.int < other
         if isinstance(other, str):
-            return self.str() < other
+            return self.str < other
         return NotImplemented
 
     def __gt__(self, other):
         if isinstance(other, MemoryView):
-            return self.int() > other.int()
+            return self.int > other.int
         if isinstance(other, (bytes, bytearray)):
-            return self.bytes() > other
+            return self.bytes > other
         if isinstance(other, memoryview):
-            return self.bytes() > other.tobytes()
+            return self.bytes > other.tobytes()
         if isinstance(other, int):
-            return self.int() > other
+            return self.int > other
         if isinstance(other, str):
-            return self.str() > other
+            return self.str > other
         return NotImplemented
 
     def __le__(self, other):
         if isinstance(other, MemoryView):
-            return self.int() <= other.int()
+            return self.int <= other.int
         if isinstance(other, (bytes, bytearray)):
-            return self.bytes() <= other
+            return self.bytes <= other
         if isinstance(other, memoryview):
-            return self.bytes() <= other.tobytes()
+            return self.bytes <= other.tobytes()
         if isinstance(other, int):
-            return self.int() <= other
+            return self.int <= other
         if isinstance(other, str):
-            return self.str() <= other
+            return self.str <= other
         return NotImplemented
 
     def __ge__(self, other):
         if isinstance(other, MemoryView):
-            return self.int() >= other.int()
+            return self.int >= other.int
         if isinstance(other, (bytes, bytearray)):
-            return self.bytes() >= other
+            return self.bytes >= other
         if isinstance(other, memoryview):
-            return self.bytes() >= other.tobytes()
+            return self.bytes >= other.tobytes()
         if isinstance(other, int):
-            return self.int() >= other
+            return self.int >= other
         if isinstance(other, str):
-            return self.str() >= other
+            return self.str >= other
         return NotImplemented
 
     def __hash__(self):
         return hash(self.memory)
 
     def __int__(self):
-        return self.int()
+        return self.int
 
     def __repr__(self):
         return '<{}({!r})>'.format(self.__class__.__name__, str(self))
 
     def __str__(self):
-        return self.str()
+        return self.str
 
+    @property
     def bytes(self) -> bytes:
         """
         Computes the bytes value of the underlying :class:`~memoryview`.
@@ -119,6 +120,7 @@ class MemoryView:
         """
         return self.memory.tobytes()
 
+    @property
     def int(self) -> int:
         """
         Computes the integer value of the underlying :class:`~memoryview` in big-endian byte order.
@@ -128,6 +130,7 @@ class MemoryView:
         """
         return int.from_bytes(self.memory, byteorder='big')
 
+    @property
     def str(self) -> str:
         """
         Computes the string value of the underlying :class:`~memoryview` in Base32 encoding.
@@ -155,6 +158,7 @@ class Timestamp(MemoryView):
 
     __slots__ = MemoryView.__slots__
 
+    @property
     def str(self) -> str:
         """
         Computes the string value of the timestamp from the underlying :class:`~memoryview` in Base32 encoding.
@@ -165,6 +169,7 @@ class Timestamp(MemoryView):
         """
         return base32.encode_timestamp(self.memory)
 
+    @property
     def timestamp(self) -> float:
         """
         Computes the Unix time (seconds since epoch) from its :class:`~memoryview`.
@@ -172,8 +177,9 @@ class Timestamp(MemoryView):
         :return: Timestamp in Unix time (seconds since epoch) form.
         :rtype: :class:`~float`
         """
-        return self.int() / 1000.0
+        return self.int / 1000.0
 
+    @property
     def datetime(self) -> datetime.datetime:
         """
         Creates a :class:`~datetime.datetime` instance (assumes UTC) from the Unix time value of the timestamp
@@ -182,7 +188,7 @@ class Timestamp(MemoryView):
         :return: Timestamp in datetime form.
         :rtype: :class:`~datetime.datetime`
         """
-        ms = self.int()
+        ms = self.int
         return datetime.datetime.utcfromtimestamp(ms // 1000.0).replace(microsecond=ms % 1000 * 1000)
 
 
@@ -197,6 +203,7 @@ class Randomness(MemoryView):
 
     __slots__ = MemoryView.__slots__
 
+    @property
     def str(self) -> str:
         """
         Computes the string value of the randomness from the underlying :class:`~memoryview` in Base32 encoding.
@@ -220,6 +227,7 @@ class ULID(MemoryView):
 
     __slots__ = MemoryView.__slots__
 
+    @property
     def str(self) -> str:
         """
         Computes the string value of the ULID from its :class:`~memoryview` in Base32 encoding.
@@ -248,6 +256,7 @@ class ULID(MemoryView):
         """
         return Randomness(self.memory[6:])
 
+    @property
     def uuid(self) -> uuid.UUID:
         """
         Creates a :class:`~uuid.UUID` instance of the ULID from its :class:`~bytes` representation.
@@ -255,4 +264,4 @@ class ULID(MemoryView):
         :return: UUIDv4 from the ULID bytes
         :rtype: :class:`~uuid.UUID`
         """
-        return uuid.UUID(bytes=self.bytes())
+        return uuid.UUID(bytes=self.bytes)


### PR DESCRIPTION
The only two calls that remain functions instead of properties is `ULID.timestamp` and `ULID.randomness`.