### PR TITLE
Pin all requirements to latest versions (if usable).

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,4 +2,4 @@
 #
 # Requirements for using this package.
 
-typing; python_version < '3.6'
+typing==3.6.1; python_version < '3.6'

--- a/requirements/codeclimate.txt
+++ b/requirements/codeclimate.txt
@@ -4,4 +4,4 @@
 
 -r travis.txt
 
-codeclimate-test-reporter
+codeclimate-test-reporter==0.2.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,6 @@
 
 -r base.txt
 
-bumpversion
-mypy
-pylint
+bumpversion==0.5.3
+mypy==0.511
+pylint==1.7.2

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,4 +5,4 @@
 -r base.txt
 
 sphinx==1.5.2
-sphinx_rtd_theme
+sphinx_rtd_theme==0.1.9

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,8 +6,8 @@
 
 coverage>4.0,<4.4
 
-pytest
-pytest-benchmark
-pytest-cov
-pytest-mock
-pytest-pep8
+pytest==3.1.2
+pytest-benchmark==3.0.0
+pytest-cov==2.5.1
+pytest-mock==1.6.0
+pytest-pep8==1.0.6

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,4 +4,4 @@
 
 -r test.txt
 
-tox
+tox==2.7.0

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,4 +4,4 @@
 
 -r tox.txt
 
-tox-travis
+tox-travis==0.8


### PR DESCRIPTION
Fixes #29.

The version of the "coverage" dependency is still variable due to
a regression in the latest version that breaks coverage reporting
for Codeclimate.