### PR TITLE
Refactor security scan into separate Travis CI job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   include:
   - python: '3.6'
     env: TOXENV=lint
+  - python: '3.6'
+    env: TOXENV=scan
 install: make travis-install
 script: make travis-script
 after_success: codeclimate-test-reporter

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ test: test-install  ## Run test suite.
 benchmark: test-install  ## Run performance suite.
 	@py.test -v tests/benchmarks
 
-.PHONY: safety-check
-safety-check: test-install  ## Run vuln saftey check scan.
+.PHONY: scan
+scan: test-install  ## Run security scan.
 	@safety check
 
 .PHONY: tox-install
@@ -29,7 +29,7 @@ travis-install: codeclimate-install  ## Install dependencies for travis-ci.org i
 	@pip install -q -r requirements/travis.txt
 
 .PHONY: travis-script
-travis-script: travis-install tox safety-check  ## Entry point for travis-ci.org execution.
+travis-script: travis-install tox scan  ## Entry point for travis-ci.org execution.
 
 .PHONY: codeclimate-install
 codeclimate-install:  ## Install dependencies required for codeclimate.com integration.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ travis-install: codeclimate-install  ## Install dependencies for travis-ci.org i
 	@pip install -q -r requirements/travis.txt
 
 .PHONY: travis-script
-travis-script: travis-install tox scan  ## Entry point for travis-ci.org execution.
+travis-script: travis-install tox  ## Entry point for travis-ci.org execution.
 
 .PHONY: codeclimate-install
 codeclimate-install:  ## Install dependencies required for codeclimate.com integration.

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36, lint
+envlist = py33, py34, py35, py36, lint, scan
 
 [testenv]
 commands = make test
@@ -8,6 +8,9 @@ usedevelop = true
 
 [testenv:lint]
 commands = make lint
+
+[testenv:scan]
+commands = make scan
 
 [travis]
 python =


### PR DESCRIPTION
* Renames 'security-check' target to 'scan'.
* Removes 'scan' target from default Travis CI 'travis-script' target.
* Include new Travis CI job for 'scan' TOXENV.