### PR TITLE
Fix non-ascii character set tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,15 +218,6 @@ def extended_ascii_str_16():
     return random_str(16, alphabet=EXTENDED_ASCII_ALPHABET)
 
 
-@pytest.fixture(scope='function', params=range(0, 32))
-def extended_ascii_str_encoding(request):
-    """
-    Fixture that yields :class:`~str` instances that are between 0 and 32 characters
-    that uses non-ascii characters.
-    """
-    return random_str(request.param, alphabet=EXTENDED_ASCII_ALPHABET)
-
-
 def random_bytes(num_bytes, not_in=(-1,)):
     """
     Helper function that returns a number of random bytes, optionally excluding those of a specific length.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,6 +182,42 @@ def invalid_str_10_16_26(request):
     return random_str(request.param, not_in=[10, 16, 26])
 
 
+@pytest.fixture(scope='function', params=[10, 16, 26])
+def extended_ascii_str_valid_length(request):
+    """
+    Fixture that yields a :class:`~str` instance that is valid length for a ULID part but
+    contains extended ASCII characters.
+    """
+    return random_str(request.param, alphabet=EXTENDED_ASCII_ALPHABET)
+
+
+@pytest.fixture(scope='function')
+def extended_ascii_str_26():
+    """
+    Fixture that yields a :class:`~str` instance that is 26 characters, the length of an entire ULID but
+    contains extended ASCII characters.
+    """
+    return random_str(26, alphabet=EXTENDED_ASCII_ALPHABET)
+
+
+@pytest.fixture(scope='function')
+def extended_ascii_str_10():
+    """
+    Fixture that yields a :class:`~str` instance that is 10 characters, the length of a ULID timestamp value but
+    contains extended ASCII characters.
+    """
+    return random_str(10, alphabet=EXTENDED_ASCII_ALPHABET)
+
+
+@pytest.fixture(scope='function')
+def extended_ascii_str_16():
+    """
+    Fixture that yields a :class:`~str` instance that is 16 characters, the length of a ULID randomness value but
+    contains extended ASCII characters.
+    """
+    return random_str(16, alphabet=EXTENDED_ASCII_ALPHABET)
+
+
 @pytest.fixture(scope='function', params=range(0, 32))
 def extended_ascii_str_encoding(request):
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import random
 from ulid import base32
 
 
-NON_ASCII_ALPHABET = ''.join(chr(d) for d in range(128, 256))
+EXTENDED_ASCII_ALPHABET = ''.join(chr(d) for d in range(128, 256))
 
 
 @pytest.fixture(scope='session')
@@ -188,7 +188,7 @@ def invalid_str_encoding(request):
     Fixture that yields :class:`~str` instances that are between 0 and 32 characters
     that uses non-ascii characters.
     """
-    return random_str(request.param, alphabet=NON_ASCII_ALPHABET)
+    return random_str(request.param, alphabet=EXTENDED_ASCII_ALPHABET)
 
 
 def random_bytes(num_bytes, not_in=(-1,)):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,7 +183,7 @@ def invalid_str_10_16_26(request):
 
 
 @pytest.fixture(scope='function', params=range(0, 32))
-def invalid_str_encoding(request):
+def extended_ascii_str_encoding(request):
     """
     Fixture that yields :class:`~str` instances that are between 0 and 32 characters
     that uses non-ascii characters.

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -152,13 +152,13 @@ def test_decode_raises_on_str_length_mismatch(invalid_str_10_16_26):
         base32.decode(invalid_str_10_16_26)
 
 
-def test_decode_raises_on_non_ascii_str(extended_ascii_str_encoding):
+def test_decode_raises_on_extended_ascii_str(extended_ascii_str_valid_length):
     """
     Assert that :func:`~ulid.base32.decode` raises a :class:`~ValueError` when given a :class:`~str`
-    instance that contains non-ascii characters.
+    instance that contains extended ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode(extended_ascii_str_encoding)
+        base32.decode(extended_ascii_str_valid_length)
 
 
 def test_decode_ulid_returns_16_bytes(valid_str_26):
@@ -180,13 +180,13 @@ def test_decode_ulid_raises_on_str_length_mismatch(invalid_str_26):
         base32.decode_ulid(invalid_str_26)
 
 
-def test_decode_ulid_raises_on_non_ascii_str(extended_ascii_str_encoding):
+def test_decode_ulid_raises_on_non_ascii_str(extended_ascii_str_26):
     """
     Assert that :func:`~ulid.base32.decode_ulid` raises a :class:`~ValueError` when given a :class:`~str`
-    instance that contains non-ascii characters.
+    instance that contains extended ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_ulid(extended_ascii_str_encoding)
+        base32.decode_ulid(extended_ascii_str_26)
 
 
 def test_decode_timestamp_returns_6_bytes(valid_str_10):
@@ -208,13 +208,13 @@ def test_decode_timestamp_raises_on_str_length_mismatch(invalid_str_10):
         base32.decode_timestamp(invalid_str_10)
 
 
-def test_decode_timestamp_raises_on_non_ascii_str(extended_ascii_str_encoding):
+def test_decode_timestamp_raises_on_non_ascii_str(extended_ascii_str_10):
     """
     Assert that :func:`~ulid.base32.decode_timestamp` raises a :class:`~ValueError` when given a :class:`~str`
-    instance that contains non-ascii characters.
+    instance that contains extended ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_timestamp(extended_ascii_str_encoding)
+        base32.decode_timestamp(extended_ascii_str_10)
 
 
 def test_decode_randomness_returns_10_bytes(valid_str_16):
@@ -236,13 +236,13 @@ def test_decode_randomness_raises_on_str_length_mismatch(invalid_str_16):
         base32.decode_randomness(invalid_str_16)
 
 
-def test_decode_randomness_raises_on_non_ascii_str(extended_ascii_str_encoding):
+def test_decode_randomness_raises_on_non_ascii_str(extended_ascii_str_16):
     """
     Assert that :func:`~ulid.base32.decode_randomness` raises a :class:`~ValueError` when given a :class:`~str`
-    instance that contains non-ascii characters.
+    instance that contains extended ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_randomness(extended_ascii_str_encoding)
+        base32.decode_randomness(extended_ascii_str_16)
 
 
 def test_decode_table_has_value_for_entire_decoding_alphabet(decoding_alphabet):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -152,13 +152,13 @@ def test_decode_raises_on_str_length_mismatch(invalid_str_10_16_26):
         base32.decode(invalid_str_10_16_26)
 
 
-def test_decode_raises_on_non_ascii_str(invalid_str_encoding):
+def test_decode_raises_on_non_ascii_str(extended_ascii_str_encoding):
     """
     Assert that :func:`~ulid.base32.decode` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains non-ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode(invalid_str_encoding)
+        base32.decode(extended_ascii_str_encoding)
 
 
 def test_decode_ulid_returns_16_bytes(valid_str_26):
@@ -180,13 +180,13 @@ def test_decode_ulid_raises_on_str_length_mismatch(invalid_str_26):
         base32.decode_ulid(invalid_str_26)
 
 
-def test_decode_ulid_raises_on_non_ascii_str(invalid_str_encoding):
+def test_decode_ulid_raises_on_non_ascii_str(extended_ascii_str_encoding):
     """
     Assert that :func:`~ulid.base32.decode_ulid` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains non-ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_ulid(invalid_str_encoding)
+        base32.decode_ulid(extended_ascii_str_encoding)
 
 
 def test_decode_timestamp_returns_6_bytes(valid_str_10):
@@ -208,13 +208,13 @@ def test_decode_timestamp_raises_on_str_length_mismatch(invalid_str_10):
         base32.decode_timestamp(invalid_str_10)
 
 
-def test_decode_timestamp_raises_on_non_ascii_str(invalid_str_encoding):
+def test_decode_timestamp_raises_on_non_ascii_str(extended_ascii_str_encoding):
     """
     Assert that :func:`~ulid.base32.decode_timestamp` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains non-ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_timestamp(invalid_str_encoding)
+        base32.decode_timestamp(extended_ascii_str_encoding)
 
 
 def test_decode_randomness_returns_10_bytes(valid_str_16):
@@ -236,13 +236,13 @@ def test_decode_randomness_raises_on_str_length_mismatch(invalid_str_16):
         base32.decode_randomness(invalid_str_16)
 
 
-def test_decode_randomness_raises_on_non_ascii_str(invalid_str_encoding):
+def test_decode_randomness_raises_on_non_ascii_str(extended_ascii_str_encoding):
     """
     Assert that :func:`~ulid.base32.decode_randomness` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains non-ascii characters.
     """
     with pytest.raises(ValueError):
-        base32.decode_randomness(invalid_str_encoding)
+        base32.decode_randomness(extended_ascii_str_encoding)
 
 
 def test_decode_table_has_value_for_entire_decoding_alphabet(decoding_alphabet):


### PR DESCRIPTION
This PR contains some general naming refactoring
(non-ascii vs. extended-ascii) and fixes those tests
to assert on the correct code path exception.

Fixes #61