### PR TITLE
Refactor tests to assert on exception messages.

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from ulid import api, base32, ulid
 
 
 BYTES_SIZE_EXC_REGEX = r'Expects bytes to be 128 bits'
+INT_SIZE_EXC_REGEX = r'Expects integer to be 128 bits'
 
 
 @pytest.fixture(scope='session', params=[
@@ -83,8 +84,9 @@ def test_from_int_raises_when_not_128_bits(invalid_bytes_128):
     that is not 128 bit in length.
     """
     value = int.from_bytes(invalid_bytes_128, byteorder='big')
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_int(value)
+    assert ex.match(INT_SIZE_EXC_REGEX)
 
 
 def test_from_str_returns_ulid_instance(valid_bytes_128):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ from ulid import api, base32, ulid
 
 BYTES_SIZE_EXC_REGEX = r'Expects bytes to be 128 bits'
 INT_SIZE_EXC_REGEX = r'Expects integer to be 128 bits'
+STR_SIZE_EXC_REGEX = r'Expects 26 characters'
 
 
 @pytest.fixture(scope='session', params=[
@@ -106,8 +107,9 @@ def test_from_str_raises_when_not_128_bits(valid_bytes_48):
     that is not 128 bit in length.
     """
     value = base32.encode(valid_bytes_48)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_str(value)
+    assert ex.match(STR_SIZE_EXC_REGEX)
 
 
 def test_from_uuid_returns_ulid_instance():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,9 @@ from ulid import api, base32, ulid
 BYTES_SIZE_EXC_REGEX = r'Expects bytes to be 128 bits'
 INT_SIZE_EXC_REGEX = r'Expects integer to be 128 bits'
 STR_SIZE_EXC_REGEX = r'Expects 26 characters'
+UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX = (r'Expected datetime, int, float, str, memoryview, Timestamp'
+                                        r', ULID, bytes, or bytearray')
+TIMESTAMP_SIZE_EXC_REGEX = r'Expects timestamp to be 48 bits'
 
 
 @pytest.fixture(scope='session', params=[
@@ -205,8 +208,9 @@ def test_from_timestamp_with_unsupported_type_raises(unsupported_type):
     Assert that :func:`~ulid.api.from_timestamp` raises a :class:`~ValueError` when given
     a type it cannot compute a timestamp value from.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_timestamp(unsupported_type())
+    assert ex.match(UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX)
 
 
 def test_from_timestamp_with_incorrect_size_bytes_raises(valid_bytes_128):
@@ -214,8 +218,9 @@ def test_from_timestamp_with_incorrect_size_bytes_raises(valid_bytes_128):
     Assert that :func:`~ulid.api.from_timestamp` raises a :class:`~ValueError` when given
     a type that cannot be represented as exactly 48 bits.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_timestamp(valid_bytes_128)
+    assert ex.match(TIMESTAMP_SIZE_EXC_REGEX)
 
 
 def test_from_randomness_int_returns_ulid_instance(valid_bytes_80):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,6 +12,9 @@ import uuid
 from ulid import api, base32, ulid
 
 
+BYTES_SIZE_EXC_REGEX = r'Expects bytes to be 128 bits'
+
+
 @pytest.fixture(scope='session', params=[
     list,
     dict,
@@ -58,8 +61,9 @@ def test_from_bytes_raises_when_not_128_bits(buffer_type, invalid_bytes_128):
     that is not 128 bit in length.
     """
     value = buffer_type(invalid_bytes_128)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_bytes(value)
+    assert ex.match(BYTES_SIZE_EXC_REGEX)
 
 
 def test_from_int_returns_ulid_instance(valid_bytes_128):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,8 @@ STR_SIZE_EXC_REGEX = r'Expects 26 characters'
 UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX = (r'Expected datetime, int, float, str, memoryview, Timestamp'
                                         r', ULID, bytes, or bytearray')
 TIMESTAMP_SIZE_EXC_REGEX = r'Expects timestamp to be 48 bits'
+UNSUPPORTED_RANDOMNESS_TYPE_EXC_REGEX = r'Expected int, float, str, memoryview, Randomness, ULID, bytes, or bytearray'
+RANDOMNESS_SIZE_EXC_REGEX = r'Expects randomness to be 80 bits'
 
 
 @pytest.fixture(scope='session', params=[
@@ -294,8 +296,9 @@ def test_from_randomness_with_unsupported_type_raises(unsupported_type):
     Assert that :func:`~ulid.api.from_randomness` raises a :class:`~ValueError` when given
     a type it cannot compute a randomness value from.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_randomness(unsupported_type())
+    assert ex.match(UNSUPPORTED_RANDOMNESS_TYPE_EXC_REGEX)
 
 
 def test_from_randomness_with_incorrect_size_bytes_raises(valid_bytes_128):
@@ -303,5 +306,6 @@ def test_from_randomness_with_incorrect_size_bytes_raises(valid_bytes_128):
     Assert that :func:`~ulid.api.from_randomness` raises a :class:`~ValueError` when given
     a type that cannot be represented as exactly 80 bits.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         api.from_randomness(valid_bytes_128)
+    assert ex.match(RANDOMNESS_SIZE_EXC_REGEX)

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -10,10 +10,12 @@ from ulid import base32
 
 
 NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
+NON_ASCII_EXC_REGEX = r'Expects value that can be encoded in ASCII charset'
 ENCODE_BYTE_SIZE_EXC_REGEX = r'^Expects bytes in sizes of'
 ENCODE_ULID_BYTE_SIZE_EXC_REGEX = r'Expects 16 bytes for'
 ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX = r'Expects 6 bytes for'
 ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX = r'Expects 10 bytes for'
+DECODE_STR_LEN_EXC_REGEX = r'^Expects string in lengths of'
 
 
 @pytest.fixture(scope='session')
@@ -159,8 +161,9 @@ def test_decode_raises_on_str_length_mismatch(invalid_str_10_16_26):
     Assert that :func:`~ulid.base32.decode` raises a :class:`~ValueError` when given a :class:`~str`
     instance that is not exactly 10, 16, 26 characters in length.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode(invalid_str_10_16_26)
+    assert ex.match(DECODE_STR_LEN_EXC_REGEX)
 
 
 def test_decode_raises_on_extended_ascii_str(extended_ascii_str_valid_length):
@@ -168,8 +171,9 @@ def test_decode_raises_on_extended_ascii_str(extended_ascii_str_valid_length):
     Assert that :func:`~ulid.base32.decode` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains extended ascii characters.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode(extended_ascii_str_valid_length)
+    assert ex.match(NON_ASCII_EXC_REGEX)
 
 
 def test_decode_raises_on_non_base32_decode_char(ascii_non_base32_str_valid_length):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -9,7 +9,7 @@ import pytest
 from ulid import base32
 
 
-NON_BASE_32_EXP = r'^Non-base32 character found'
+NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
 
 
 @pytest.fixture(scope='session')
@@ -171,7 +171,7 @@ def test_decode_raises_on_non_base32_decode_char(ascii_non_base32_str_valid_leng
     """
     with pytest.raises(ValueError) as ex:
         base32.decode(ascii_non_base32_str_valid_length)
-    ex.match(NON_BASE_32_EXP)
+    ex.match(NON_BASE_32_EXC_REGEX)
 
 
 def test_decode_ulid_returns_16_bytes(valid_str_26):
@@ -209,7 +209,7 @@ def test_decode_ulid_raises_on_non_base32_decode_char(ascii_non_base32_str_26):
     """
     with pytest.raises(ValueError) as ex:
         base32.decode_ulid(ascii_non_base32_str_26)
-    ex.match(NON_BASE_32_EXP)
+    ex.match(NON_BASE_32_EXC_REGEX)
 
 
 def test_decode_timestamp_returns_6_bytes(valid_str_10):
@@ -247,7 +247,7 @@ def test_decode_timestamp_raises_on_non_base32_decode_char(ascii_non_base32_str_
     """
     with pytest.raises(ValueError) as ex:
         base32.decode_timestamp(ascii_non_base32_str_10)
-    ex.match(NON_BASE_32_EXP)
+    ex.match(NON_BASE_32_EXC_REGEX)
 
 
 def test_decode_randomness_returns_10_bytes(valid_str_16):
@@ -285,7 +285,7 @@ def test_decode_randomness_raises_on_non_base32_decode_char(ascii_non_base32_str
     """
     with pytest.raises(ValueError) as ex:
         base32.decode_randomness(ascii_non_base32_str_16)
-    ex.match(NON_BASE_32_EXP)
+    ex.match(NON_BASE_32_EXC_REGEX)
 
 
 def test_decode_table_has_value_for_entire_decoding_alphabet(decoding_alphabet):
@@ -332,4 +332,4 @@ def test_str_to_bytes_raises_on_non_base32_decode_char(ascii_non_base32_str_vali
     """
     with pytest.raises(ValueError) as ex:
         base32.str_to_bytes(ascii_non_base32_str_valid_length, len(ascii_non_base32_str_valid_length))
-    ex.match(NON_BASE_32_EXP)
+    ex.match(NON_BASE_32_EXC_REGEX)

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -12,6 +12,7 @@ from ulid import base32
 NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
 ENCODE_BYTE_SIZE_EXC_REGEX = r'^Expects bytes in sizes of'
 ENCODE_ULID_BYTE_SIZE_EXC_REGEX = r'Expects 16 bytes for'
+ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX = r'Expects 6 bytes for'
 
 
 @pytest.fixture(scope='session')
@@ -97,8 +98,9 @@ def test_encode_timestamp_raises_on_bytes_length_mismatch(invalid_bytes_48):
     Assert that :func:`~ulid.base32.encode_timestamp` raises a :class:`~ValueError` when given a :class:`~bytes`
     instance that is not exactly 48 bit.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.encode_timestamp(invalid_bytes_48)
+    assert ex.match(ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX)
 
 
 def test_encode_randomness_returns_16_char_string(valid_bytes_80):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -18,6 +18,7 @@ ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX = r'Expects 10 bytes for'
 DECODE_STR_LEN_EXC_REGEX = r'^Expects string in lengths of'
 DECODE_ULID_STR_LEN_EXC_REGEX = r'^Expects 26 characters for decoding'
 DECODE_TIMESTAMP_STR_LEN_EXC_REGEX = r'^Expects 10 characters for decoding'
+DECODE_RANDOMNESS_STR_LEN_EXC_REGEX = r'^Expects 16 characters for decoding'
 
 
 @pytest.fixture(scope='session')
@@ -283,8 +284,9 @@ def test_decode_randomness_raises_on_str_length_mismatch(invalid_str_16):
     Assert that :func:`~ulid.base32.decode_randomness` raises a :class:`~ValueError` when given a :class:`~str`
     instance that is not exactly 16 chars.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_randomness(invalid_str_16)
+    assert ex.match(DECODE_RANDOMNESS_STR_LEN_EXC_REGEX)
 
 
 def test_decode_randomness_raises_on_non_ascii_str(extended_ascii_str_16):
@@ -292,8 +294,9 @@ def test_decode_randomness_raises_on_non_ascii_str(extended_ascii_str_16):
     Assert that :func:`~ulid.base32.decode_randomness` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains extended ascii characters.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_randomness(extended_ascii_str_16)
+    assert ex.match(NON_ASCII_EXC_REGEX)
 
 
 def test_decode_randomness_raises_on_non_base32_decode_char(ascii_non_base32_str_16):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -17,6 +17,7 @@ ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX = r'Expects 6 bytes for'
 ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX = r'Expects 10 bytes for'
 DECODE_STR_LEN_EXC_REGEX = r'^Expects string in lengths of'
 DECODE_ULID_STR_LEN_EXC_REGEX = r'^Expects 26 characters for decoding'
+DECODE_TIMESTAMP_STR_LEN_EXC_REGEX = r'^Expects 10 characters for decoding'
 
 
 @pytest.fixture(scope='session')
@@ -242,8 +243,9 @@ def test_decode_timestamp_raises_on_str_length_mismatch(invalid_str_10):
     Assert that :func:`~ulid.base32.decode_timestamp` raises a :class:`~ValueError` when given a :class:`~str`
     instance that is not exactly 10 chars.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_timestamp(invalid_str_10)
+    assert ex.match(DECODE_TIMESTAMP_STR_LEN_EXC_REGEX)
 
 
 def test_decode_timestamp_raises_on_non_ascii_str(extended_ascii_str_10):
@@ -251,8 +253,9 @@ def test_decode_timestamp_raises_on_non_ascii_str(extended_ascii_str_10):
     Assert that :func:`~ulid.base32.decode_timestamp` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains extended ascii characters.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_timestamp(extended_ascii_str_10)
+    assert ex.match(NON_ASCII_EXC_REGEX)
 
 
 def test_decode_timestamp_raises_on_non_base32_decode_char(ascii_non_base32_str_10):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -13,6 +13,7 @@ NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
 ENCODE_BYTE_SIZE_EXC_REGEX = r'^Expects bytes in sizes of'
 ENCODE_ULID_BYTE_SIZE_EXC_REGEX = r'Expects 16 bytes for'
 ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX = r'Expects 6 bytes for'
+ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX = r'Expects 10 bytes for'
 
 
 @pytest.fixture(scope='session')
@@ -118,8 +119,9 @@ def test_encode_randomness_raises_on_bytes_length_mismatch(invalid_bytes_80):
     Assert that :func:`~ulid.base32.encode_randomness` raises a :class:`~ValueError` when given a :class:`~bytes`
     instance that is not exactly 80 bit.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.encode_randomness(invalid_bytes_80)
+    assert ex.match(ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX)
 
 
 def test_decode_handles_ulid_and_returns_16_bytes(valid_str_26):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -333,8 +333,9 @@ def test_str_to_bytes_raises_on_unexpected_length(invalid_str_26):
     Assert that :func:`~ulid.base32.str_to_bytes` raises a :class:`~ValueError` when given a :class:`~str`
     instance that does not match the expected length.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.str_to_bytes(invalid_str_26, 26)
+    assert ex.match(DECODE_ULID_STR_LEN_EXC_REGEX)
 
 
 def test_str_to_bytes_raises_on_extended_ascii_str(extended_ascii_str_valid_length):
@@ -342,8 +343,9 @@ def test_str_to_bytes_raises_on_extended_ascii_str(extended_ascii_str_valid_leng
     Assert that :func:`~ulid.base32.str_to_bytes` raises a :class:`~ValueError` when given a :class:`~str`
     instance that includes extended ascii characters.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.str_to_bytes(extended_ascii_str_valid_length, len(extended_ascii_str_valid_length))
+    assert ex.match(NON_ASCII_EXC_REGEX)
 
 
 def test_str_to_bytes_raises_on_non_base32_decode_char(ascii_non_base32_str_valid_length):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -16,6 +16,7 @@ ENCODE_ULID_BYTE_SIZE_EXC_REGEX = r'Expects 16 bytes for'
 ENCODE_TIMESTAMP_BYTE_SIZE_EXC_REGEX = r'Expects 6 bytes for'
 ENCODE_RANDOMNESS_BYTE_SIZE_EXC_REGEX = r'Expects 10 bytes for'
 DECODE_STR_LEN_EXC_REGEX = r'^Expects string in lengths of'
+DECODE_ULID_STR_LEN_EXC_REGEX = r'^Expects 26 characters for decoding'
 
 
 @pytest.fixture(scope='session')
@@ -201,8 +202,9 @@ def test_decode_ulid_raises_on_str_length_mismatch(invalid_str_26):
     Assert that :func:`~ulid.base32.decode_ulid` raises a :class:`~ValueError` when given a :class:`~str`
     instance that is not exactly 26 chars.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_ulid(invalid_str_26)
+    assert ex.match(DECODE_ULID_STR_LEN_EXC_REGEX)
 
 
 def test_decode_ulid_raises_on_non_ascii_str(extended_ascii_str_26):
@@ -210,8 +212,9 @@ def test_decode_ulid_raises_on_non_ascii_str(extended_ascii_str_26):
     Assert that :func:`~ulid.base32.decode_ulid` raises a :class:`~ValueError` when given a :class:`~str`
     instance that contains extended ascii characters.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.decode_ulid(extended_ascii_str_26)
+    assert ex.match(NON_ASCII_EXC_REGEX)
 
 
 def test_decode_ulid_raises_on_non_base32_decode_char(ascii_non_base32_str_26):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -10,6 +10,7 @@ from ulid import base32
 
 
 NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
+ENCODE_BYTE_SIZE_EXC_REGEX = r'^Expects bytes in sizes of'
 
 
 @pytest.fixture(scope='session')
@@ -55,8 +56,9 @@ def test_encode_raises_on_bytes_length_mismatch(invalid_bytes_48_80_128):
     Assert that :func:`~ulid.base32.encode` raises a :class:`~ValueError` when given a :class:`~bytes`
     instance that is not exactly 48, 80, or 128 bits in length.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.encode(invalid_bytes_48_80_128)
+    assert ex.match(ENCODE_BYTE_SIZE_EXC_REGEX)
 
 
 def test_encode_ulid_returns_26_char_string(valid_bytes_128):

--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -11,6 +11,7 @@ from ulid import base32
 
 NON_BASE_32_EXC_REGEX = r'^Non-base32 character found'
 ENCODE_BYTE_SIZE_EXC_REGEX = r'^Expects bytes in sizes of'
+ENCODE_ULID_BYTE_SIZE_EXC_REGEX = r'Expects 16 bytes for'
 
 
 @pytest.fixture(scope='session')
@@ -76,8 +77,9 @@ def test_encode_ulid_raises_on_bytes_length_mismatch(invalid_bytes_128):
     Assert that :func:`~ulid.base32.encode_ulid` raises a :class:`~ValueError` when given a :class:`~bytes`
     instance that is not exactly 128 bit.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as ex:
         base32.encode_ulid(invalid_bytes_128)
+    assert ex.match(ENCODE_ULID_BYTE_SIZE_EXC_REGEX)
 
 
 def test_encode_timestamp_returns_10_char_string(valid_bytes_48):

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -5,6 +5,7 @@
     Tests for the :mod:`~ulid.ulid` module.
 """
 import datetime
+import operator
 import pytest
 import time
 import uuid
@@ -208,14 +209,9 @@ def test_memoryview_unorderble_with_unsupported_type(valid_bytes_128, unsupporte
     against unsupported types.
     """
     mv = ulid.MemoryView(valid_bytes_128)
-    with pytest.raises(TypeError):
-        mv < unsupported_comparison_type()
-    with pytest.raises(TypeError):
-        mv > unsupported_comparison_type()
-    with pytest.raises(TypeError):
-        mv <= unsupported_comparison_type()
-    with pytest.raises(TypeError):
-        mv >= unsupported_comparison_type()
+    for op in (operator.lt, operator.gt, operator.le, operator.ge):
+        with pytest.raises(TypeError):
+            op(mv, unsupported_comparison_type())
 
 
 def test_memoryview_supports_str(valid_bytes_128):


### PR DESCRIPTION
This change promotes correctness to remove the risk of same
exception type asserts firing even though the incorrect code
path was actually tested.

Fixes https://github.com/ahawker/ulid/issues/65