### PR TITLE
Switch from 3.7-dev to 3.7 on xenial.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7-dev'
 - nightly
 matrix:
   allow_failures:
@@ -14,6 +13,9 @@ matrix:
     env: TOXENV=lint
   - python: '3.6'
     env: TOXENV=scan
+  - python: '3.7'
+    dist: xenial
+    sudo: true
 install: make travis-install
 before_script: make travis-before-script
 script: make travis-script


### PR DESCRIPTION
Per official TravisCI communications, this is currently the proper way
to support py3.7. It's added as a separate matrix build so all builds
aren't set to use sudo: true and can run in container environments.

See: https://github.com/travis-ci/travis-ci/issues/9815