### PR TITLE
Add 'parse' to public API

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -346,7 +346,7 @@ ignored-argument-names=_.*
 max-locals=15
 
 # Maximum number of return / yield for function / method body
-max-returns=6
+max-returns=9
 
 # Maximum number of branch for function / method body
 max-branches=12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,15 @@ def invalid_str_10_16_26(request):
     return random_str(request.param, not_in=[10, 16, 26])
 
 
+@pytest.fixture(scope='function', params=range(0, 40))
+def invalid_str_10_16_26_32_36(request):
+    """
+    Fixture that yields :class:`~str` instances that are between 0 and 40 characters, except 10, 16, 26,
+    32, and 36.
+    """
+    return random_str(request.param, not_in=[10, 16, 26, 32, 36])
+
+
 @pytest.fixture(scope='function', params=[10, 16, 26])
 def ascii_non_base32_str_valid_length(request):
     """


### PR DESCRIPTION
Status: **WIP**

If merged, this PR fixes #313.

The 'from_value' method should take a value of any supported type
and make a best guess attempt to convert it to a ULID instance.

Callers should only use this method when they're confident that they've
received a value that can be represented as a ULID but are unsure what
format/type it is in.

Callers should use the other from_* methods when the type/format is known.