### PR TITLE
Include the LICENSE in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
It is required for a bdist_wheel, and it is useful to be able to do this from an sdist. pip does this to cache wheels.

Without this, from an sdist, I get:
```
$ python3 setup.py bdist_wheel
Warning: 'classifiers' should be a list, got type 'tuple'
running bdist_wheel
The [wheel] section is deprecated. Use [bdist_wheel] instead.
running build
running build_py
creating build/lib
creating build/lib/ulid
copying ulid/__init__.py -> build/lib/ulid
copying ulid/api.py -> build/lib/ulid
copying ulid/base32.py -> build/lib/ulid
copying ulid/hints.py -> build/lib/ulid
copying ulid/ulid.py -> build/lib/ulid
installing to build/bdist.linux-x86_64/wheel
running install
running install_lib
running install_egg_info
running egg_info
writing ulid_py.egg-info/PKG-INFO
writing dependency_links to ulid_py.egg-info/dependency_links.txt
writing top-level names to ulid_py.egg-info/top_level.txt
reading manifest file 'ulid_py.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'LICENSE'
writing manifest file 'ulid_py.egg-info/SOURCES.txt'
removing 'build/bdist.linux-x86_64/wheel/ulid_py-0.0.9.egg-info' (and everything under it)
Copying ulid_py.egg-info to build/bdist.linux-x86_64/wheel/ulid_py-0.0.9.egg-info
running install_scripts
error: [Errno 2] No such file or directory: 'LICENSE'
```