### PR TITLE
Freeze pylint/pytest for py34 as its now deprecated

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,9 +5,11 @@
 -r base.txt
 
 bumpversion==0.5.3
-mypy==0.730
+mypy==0.670; python_version <= '3.4'  # pyup: ignore
+mypy==0.730; python_version > '3.4'
 pylint==1.7.5; python_version < '2.7' or (python_version > '3.0' and python_version < '3.4')  # pyup: ignore
-pylint==2.4.2; (python_version > '2.7' and python_version < '3.0') or python_version >= '3.4'
+pylint==2.3.1; python_version == '3.4'  # pyup: ignore
+pylint==2.4.2; python_version > '3.4'
 safety==1.8.5
 bandit==1.6.2
 isort==4.2.15; (python_version > '3.0' and python_version < '3.4')  # pyup: ignore

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,8 @@
 coverage==4.5.4
 
 pytest<3.3.0; python_version < '3.4'  # pyup: ignore
-pytest==5.2.0; python_version >= '3.4'
+pytest==4.6.5; python_version == '3.4'  # pyup: ignore
+pytest==5.2.0; python_version > '3.4'
 pytest-benchmark==3.2.2
 pytest-cov==2.7.1
 pytest-mock==1.6.3; python_version < '3.4'  # pyup: ignore


### PR DESCRIPTION
This should fix broken Travis builds that are failing to find pylint 2.4.2 for py3.4.

