### PR TITLE
fix py.typed path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=get_long_description(),
     long_description_content_type='text/markdown',
     packages=['ulid'],
-    package_data={'ulid': ['ulid/py.typed']},
+    package_data={'ulid': ['py.typed']},
     zip_safe=False,
     classifiers=(
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
ulid-py has `py.typed` but not included in built package because of invalid `package_data` path in `setup.py`.

It cause mypy error.

```python
import ulid

print(ulid.new())
```

```
ulid_sample/a.py:1: error: Skipping analyzing 'ulid': found module but no type hints or library stubs
```

before:

```
$ python setup.py build
Warning: 'classifiers' should be a list, got type 'tuple'
running build
running build_py
creating build
creating build/lib
creating build/lib/ulid
copying ulid/__init__.py -> build/lib/ulid
copying ulid/api.py -> build/lib/ulid
copying ulid/base32.py -> build/lib/ulid
copying ulid/hints.py -> build/lib/ulid
copying ulid/ulid.py -> build/lib/ulid
```

after:

```
$ python setup.py build
Warning: 'classifiers' should be a list, got type 'tuple'
running build
running build_py
creating build
creating build/lib
creating build/lib/ulid
copying ulid/__init__.py -> build/lib/ulid
copying ulid/api.py -> build/lib/ulid
copying ulid/base32.py -> build/lib/ulid
copying ulid/hints.py -> build/lib/ulid
copying ulid/ulid.py -> build/lib/ulid
copying ulid/py.typed -> build/lib/ulid
```