### PR TITLE
Add pickle support

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,7 +40,7 @@ def unsupported_type(request):
     return request.param
 
 
-@pytest.fixture('session', params=[bytes, bytearray, memoryview])
+@pytest.fixture(scope='session', params=[bytes, bytearray, memoryview])
 def buffer_type(request):
     """
     Fixture that yields types that support the buffer protocol.

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -4,6 +4,8 @@
 
     Tests for validating reported bugs have been fixed.
 """
+import copy
+
 import pytest
 
 from ulid import api
@@ -35,3 +37,13 @@ def test_github_issue_61():
     for s in ('01BX73KC0TNH409RTFD1uXKM00', '01BX73KC0TNH409RTFD1UXKM00'):
         with pytest.raises(ValueError):
             api.from_str(s)
+
+
+def test_github_issue_452():
+    """
+    Assert that :class:`~ulid.ulid.ULID` will not raise during a deepcopy.
+
+    Issue: https://github.com/ahawker/ulid/issues/452
+    """
+    result = copy.deepcopy(api.new())
+    assert result is not None

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -4,8 +4,10 @@
 
     Tests for the :mod:`~ulid.ulid` module.
 """
+import copy
 import datetime
 import operator
+import pickle
 import time
 import uuid
 
@@ -259,13 +261,56 @@ def test_memoryview_supports_float(valid_bytes_128):
     assert float(mv) == mv.float
 
 
-def test_memoryview_defines_hash(valid_bytes_128):
+def test_memoryview_supports_hash(valid_bytes_128):
     """
     Assert that the `hash` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
     hash result of the underlying :class:`~memoryview.`
     """
     mv = ulid.MemoryView(valid_bytes_128)
     assert hash(mv) == hash(mv.memory)
+
+
+def test_memoryview_supports_getstate(valid_bytes_128):
+    """
+    Assert that the `__getstate__` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
+    str result of the underlying :class:`~memoryview.`
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    assert mv.__getstate__() == mv.str
+
+
+def test_memoryview_supports_pickle(valid_bytes_128):
+    """
+    Assert that instances of :class:`~ulid.ulid.MemoryView` can be pickled and use the
+    the str result of the underlying :class:`~memoryview.` as the serialized value.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    serialized = pickle.dumps(mv)
+    assert serialized is not None
+    assert isinstance(serialized, bytes)
+    deserialized = pickle.loads(serialized)
+    assert deserialized == mv.str
+
+
+def test_memoryview_supports_copy(valid_bytes_128):
+    """
+    Assert that instances of :class:`~ulid.ulid.MemoryView` can be copied using
+    :func:`~copy.copy`.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    copied = copy.copy(mv)
+    assert copied == mv
+
+
+def test_memoryview_supports_deepcopy(valid_bytes_128):
+    """
+    Assert that instances of :class:`~ulid.ulid.MemoryView` can be copied using
+    :func:`~copy.deepcopy`.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    data = dict(a=dict(b=dict(c=mv)))
+    copied = copy.deepcopy(data)
+    assert copied == data
 
 
 def test_timestamp_coverts_bytes_to_unix_time_seconds():

--- a/ulid/ulid.py
+++ b/ulid/ulid.py
@@ -132,6 +132,12 @@ class MemoryView:
     def __str__(self) -> hints.Str:
         return self.str
 
+    def __getstate__(self) -> hints.Str:
+        return self.str
+
+    def __setstate__(self, state: hints.Str) -> None:
+        self.memory = memoryview(base32.decode(state))
+
     @property
     def bytes(self) -> hints.Bytes:
         """


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds support for pickling `MemoryView` instances, which includes `Randomness`, `Timestamp`, and `ULID`.

Fixes #452 