### PR TITLE
Add support for bin, oct, and hex representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ will give you a snapshot of the last 80-bits.
 
 The `ULID`, `Timestamp`, and `Randomness` classes all derive from the same base class, a `MemoryView`.
 
-A `MemoryView` provides the `str`, `int`, and `bytes` methods for changing any values representation.
+A `MemoryView` provides the `bin`, `bytes`, `hex`, `int`, `oct`, and `str`, methods for changing any values representation.
 
 ```python
 >>> import ulid
@@ -134,6 +134,12 @@ True
 '01BJQMF54D093DXEAWZ6JYRPAQ'
 >>> u.int
 1810474399624548315999517391436142935
+>>> u.bin
+'0b1010111001010111101000111100101001000110100000010010001101101111010111001010111001111100110100101111011000101100101010111'
+>>> u.hex
+'0x15caf47948d0246deb95cf9a5ec5957'
+>>> u.oct
+'0o12712750745106402215572712717464573054527'
 ```
 
 A `MemoryView` also provides rich comparison functionality.

--- a/tests/test_ulid.py
+++ b/tests/test_ulid.py
@@ -225,6 +225,33 @@ def test_memoryview_unorderble_with_unsupported_type(valid_bytes_128, unsupporte
             op(mv, unsupported_comparison_type())
 
 
+def test_memoryview_supports_bin(valid_bytes_128):
+    """
+    Assert that the `bin` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
+    result of the :meth:`~ulid.ulid.MemoryView.bin` method.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    assert bin(mv) == mv.bin
+
+
+def test_memoryview_supports_hex(valid_bytes_128):
+    """
+    Assert that the `hex` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
+    result of the :meth:`~ulid.ulid.MemoryView.hex` method.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    assert hex(mv) == mv.hex
+
+
+def test_memoryview_supports_oct(valid_bytes_128):
+    """
+    Assert that the `oct` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
+    result of the :meth:`~ulid.ulid.MemoryView.oct` method.
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    assert oct(mv) == mv.oct
+
+
 def test_memoryview_supports_bytes(valid_bytes_128):
     """
     Assert that the `bytes` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
@@ -268,6 +295,15 @@ def test_memoryview_supports_hash(valid_bytes_128):
     """
     mv = ulid.MemoryView(valid_bytes_128)
     assert hash(mv) == hash(mv.memory)
+
+
+def test_memoryview_supports_index(valid_bytes_128):
+    """
+    Assert that the `__index__` representation of a :class:`~ulid.ulid.MemoryView` is equal to the
+    int value of the underlying :class:`~memoryview.`
+    """
+    mv = ulid.MemoryView(valid_bytes_128)
+    assert mv.__index__() == mv.int
 
 
 def test_memoryview_supports_getstate(valid_bytes_128):

--- a/ulid/ulid.py
+++ b/ulid/ulid.py
@@ -126,6 +126,9 @@ class MemoryView:
     def __int__(self) -> hints.Int:
         return self.int
 
+    def __index__(self) -> hints.Int:
+        return self.int
+
     def __repr__(self) -> hints.Str:
         return '<{}({!r})>'.format(self.__class__.__name__, str(self))
 
@@ -137,6 +140,16 @@ class MemoryView:
 
     def __setstate__(self, state: hints.Str) -> None:
         self.memory = memoryview(base32.decode(state))
+
+    @property
+    def bin(self) -> hints.Str:
+        """
+        Computes the binary string value of the underlying :class:`~memoryview`.
+
+        :return: Memory in binary string form
+        :rtype: :class:`~str`
+        """
+        return bin(self.int)
 
     @property
     def bytes(self) -> hints.Bytes:
@@ -159,6 +172,16 @@ class MemoryView:
         return float(self.int)
 
     @property
+    def hex(self) -> hints.Str:
+        """
+        Computes the hexadecimal string value of the underlying :class:`~memoryview`.
+
+        :return: Memory in hexadecimal string form
+        :rtype: :class:`~str`
+        """
+        return hex(self.int)
+
+    @property
     def int(self) -> hints.Int:
         """
         Computes the integer value of the underlying :class:`~memoryview` in big-endian byte order.
@@ -167,6 +190,16 @@ class MemoryView:
         :rtype: :class:`~int`
         """
         return int.from_bytes(self.memory, byteorder='big')
+
+    @property
+    def oct(self) -> hints.Str:
+        """
+        Computes the octal string value of the underlying :class:`~memoryview`.
+
+        :return: Memory in octal string form
+        :rtype: :class:`~str`
+        """
+        return oct(self.int)
 
     @property
     def str(self) -> hints.Str:


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds support for the `bin`, `oct`, and `hex` properties on the `MemoryView` class. It also implements `__index__` so it can be transparently converted with the global python functions.

```python
>>> import ulid
>>> u = ulid.new()
>>> u.bin
'0b1011100111101010011010110101011010111011010010011101011101001111010000101001010011100000100100011101011000011111000001101'
>>> bin(u)
'0b1011100111101010011010110101011010111011010010011101011101001111010000101001010011100000100100011101011000011111000001101'
>>> u.hex
'0x173d4d6ad7693ae9e8529c123ac3e0d'
>>> hex(u)
'0x173d4d6ad7693ae9e8529c123ac3e0d'
>>> u.oct
'0o13475232653273223535172051234044353037015'
>>> oct(u)
'0o13475232653273223535172051234044353037015'
```