### PR TITLE
Add API create method and min/max constants

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,6 +48,54 @@ def buffer_type(request):
     return request.param
 
 
+def test_min_timestamp_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MIN_TIMESTAMP` uses expected byte value.
+    """
+    value = api.MIN_TIMESTAMP
+    assert value == b'\x00\x00\x00\x00\x00\x00'
+
+
+def test_max_timestamp_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MAX_RANDOMNESS` uses expected byte value.
+    """
+    value = api.MAX_TIMESTAMP
+    assert value == b'\xff\xff\xff\xff\xff\xff'
+
+
+def test_min_randomness_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MIN_RANDOMNESS` uses expected byte value.
+    """
+    value = api.MIN_RANDOMNESS
+    assert value == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+
+def test_max_randomness_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MAX_RANDOMNESS` uses expected byte value.
+    """
+    value = api.MAX_RANDOMNESS
+    assert value == b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+
+
+def test_min_ulid_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MIN_ULID` uses expected byte value.
+    """
+    value = api.MIN_ULID
+    assert value == b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+
+def test_max_ulid_uses_expected_value():
+    """
+    Assert that :func:`~ulid.api.MAX_ULID` uses expected byte value.
+    """
+    value = api.MAX_ULID
+    assert value == b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
+
+
 def test_new_returns_ulid_instance():
     """
     Assert that :func:`~ulid.api.new` returns a new :class:`~ulid.ulid.ULID` instance.
@@ -238,6 +286,170 @@ def test_parse_raises_when_given_unsupported_type(unsupported_type):
     assert ex.match(PARSE_UNSUPPORTED_TYPE_REGEX)
 
 
+def test_create_timestamp_datetime_returns_ulid_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given Unix time from epoch in seconds as an :class:`~datetime.datetime`.
+    """
+    value = datetime.datetime.now()
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert int(instance.timestamp().timestamp) == int(value.timestamp())
+
+
+def test_create_timestamp_int_returns_ulid_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given Unix time from epoch in seconds as an :class:`~int`.
+    """
+    value = int(time.time())
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert int(instance.timestamp().timestamp) == value
+
+
+def test_create_timestamp_float_returns_ulid_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given Unix time from epoch in seconds as a :class:`~float`.
+    """
+    value = float(time.time())
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert int(instance.timestamp().timestamp) == int(value)
+
+
+def test_create_timestamp_str_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as a :class:`~str`.
+    """
+    value = base32.encode_timestamp(valid_bytes_48)
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp().str == value
+
+
+def test_create_timestamp_bytes_returns_ulid_instance(buffer_type, valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as an object that supports the buffer protocol.
+    """
+    value = buffer_type(valid_bytes_48)
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp().bytes == value
+
+
+def test_create_timestamp_timestamp_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as a :class:`~ulid.ulid.Timestamp`.
+    """
+    value = ulid.Timestamp(valid_bytes_48)
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp() == value
+
+
+def test_create_timestamp_ulid_returns_ulid_instance(valid_bytes_128, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given timestamp as a :class:`~ulid.ulid.ULID`.
+    """
+    value = ulid.ULID(valid_bytes_128)
+    instance = api.create(value, valid_bytes_80)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.timestamp() == value.timestamp()
+
+
+def test_create_raises_when_given_unsupported_timestamp_type(unsupported_type, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` raises a :class:`~ValueError` when timestamp value
+    of an unsupported type.
+    """
+    with pytest.raises(ValueError) as ex:
+        api.create(unsupported_type, valid_bytes_80)
+    assert ex.match(UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX)
+
+
+def test_create_randomness_int_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as an :class:`~int`.
+    """
+    value = int.from_bytes(valid_bytes_80, byteorder='big')
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness().int == value
+
+
+def test_create_randomness_float_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as an :class:`~float`.
+    """
+    value = float(int.from_bytes(valid_bytes_80, byteorder='big'))
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness().int == int(value)
+
+
+def test_create_randomness_str_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as an :class:`~str`.
+    """
+    value = base32.encode_randomness(valid_bytes_80)
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness().str == value
+
+
+def test_create_randomness_bytes_returns_ulid_instance(buffer_type, valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as an object that supports the buffer protocol.
+    """
+    value = buffer_type(valid_bytes_80)
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness().bytes == value
+
+
+def test_create_randomness_randomness_returns_ulid_instance(valid_bytes_48, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as a :class:`~ulid.ulid.Randomness`.
+    """
+    value = ulid.Randomness(valid_bytes_80)
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness() == value
+
+
+def test_create_randomness_ulid_returns_ulid_instance(valid_bytes_48, valid_bytes_128):
+    """
+    Assert that :func:`~ulid.api.create` returns a new :class:`~ulid.ulid.ULID` instance
+    from the given random values as a :class:`~ulid.ulid.ULID`.
+    """
+    value = ulid.ULID(valid_bytes_128)
+    instance = api.create(valid_bytes_48, value)
+    assert isinstance(instance, ulid.ULID)
+    assert instance.randomness() == value.randomness()
+
+
+def test_create_raises_when_given_unsupported_randomness_type(unsupported_type, valid_bytes_48):
+    """
+    Assert that :func:`~ulid.api.create` raises a :class:`~ValueError` when randomness value
+    of an unsupported type.
+    """
+    with pytest.raises(ValueError) as ex:
+        api.create(valid_bytes_48, unsupported_type)
+    assert ex.match(UNSUPPORTED_RANDOMNESS_TYPE_EXC_REGEX)
+
+
 def test_from_bytes_returns_ulid_instance(buffer_type, valid_bytes_128):
     """
     Assert that :func:`~ulid.api.from_bytes` returns a new :class:`~ulid.ulid.ULID` instance
@@ -328,7 +540,7 @@ def test_from_uuid_returns_ulid_instance():
 def test_from_timestamp_datetime_returns_ulid_instance():
     """
     Assert that :func:`~ulid.api.from_timestamp` returns a new :class:`~ulid.ulid.ULID` instance
-    from the given Unix time from epoch in seconds as an :class:`~datetime.dateime`.
+    from the given Unix time from epoch in seconds as an :class:`~datetime.datetime`.
     """
     value = datetime.datetime.now()
     instance = api.from_timestamp(value)

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,224 @@
+"""
+    test_codec
+    ~~~~~~~~~~
+
+    Tests for the :mod:`~ulid.codec` module.
+"""
+import datetime
+import time
+
+import pytest
+
+from ulid import base32, codec, ulid
+
+UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX = (r'Expected datetime, int, float, str, memoryview, Timestamp'
+                                        r', ULID, bytes, or bytearray')
+TIMESTAMP_SIZE_EXC_REGEX = r'Expects timestamp to be 48 bits'
+UNSUPPORTED_RANDOMNESS_TYPE_EXC_REGEX = r'Expected int, float, str, memoryview, Randomness, ULID, bytes, or bytearray'
+RANDOMNESS_SIZE_EXC_REGEX = r'Expects randomness to be 80 bits'
+
+
+@pytest.fixture(scope='session', params=[
+    list,
+    dict,
+    set,
+    tuple,
+    type(None)
+])
+def unsupported_type(request):
+    """
+    Fixture that yields types that a cannot be converted to a timestamp/randomness.
+    """
+    return request.param
+
+
+@pytest.fixture(scope='session', params=[bytes, bytearray, memoryview])
+def buffer_type(request):
+    """
+    Fixture that yields types that support the buffer protocol.
+    """
+    return request.param
+
+
+def test_decode_timestamp_datetime_returns_timestamp_instance():
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given Unix time from epoch in seconds as an :class:`~datetime.datetime`.
+    """
+    value = datetime.datetime.now()
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert int(instance.timestamp) == int(value.timestamp())
+
+
+def test_decode_timestamp_int_returns_timestamp_instance():
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given Unix time from epoch in seconds as an :class:`~int`.
+    """
+    value = int(time.time())
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert int(instance.timestamp) == value
+
+
+def test_decode_timestamp_float_returns_timestamp_instance():
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given Unix time from epoch in seconds as a :class:`~float`.
+    """
+    value = float(time.time())
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert int(instance.timestamp) == int(value)
+
+
+def test_decode_timestamp_str_returns_timestamp_instance(valid_bytes_48):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given timestamp as a :class:`~str`.
+    """
+    value = base32.encode_timestamp(valid_bytes_48)
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert instance.str == value
+
+
+def test_decode_timestamp_bytes_returns_timestamp_instance(buffer_type, valid_bytes_48):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given timestamp as an object that supports the buffer protocol.
+    """
+    value = buffer_type(valid_bytes_48)
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert instance.bytes == value
+
+
+def test_decode_timestamp_timestamp_returns_timestamp_instance(valid_bytes_48):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given timestamp as a :class:`~ulid.ulid.Timestamp`.
+    """
+    value = ulid.Timestamp(valid_bytes_48)
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert instance == value
+
+
+def test_decode_timestamp_ulid_returns_timestamp_instance(valid_bytes_128):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` returns a new :class:`~ulid.ulid.Timestamp` instance
+    from the given timestamp as a :class:`~ulid.ulid.ULID`.
+    """
+    value = ulid.ULID(valid_bytes_128)
+    instance = codec.decode_timestamp(value)
+    assert isinstance(instance, ulid.Timestamp)
+    assert instance == value.timestamp()
+
+
+def test_decode_timestamp_with_unsupported_type_raises(unsupported_type):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` raises a :class:`~ValueError` when given
+    a type it cannot compute a timestamp value from.
+    """
+    with pytest.raises(ValueError) as ex:
+       codec.decode_timestamp(unsupported_type())
+    assert ex.match(UNSUPPORTED_TIMESTAMP_TYPE_EXC_REGEX)
+
+
+def test_decode_timestamp_with_incorrect_size_bytes_raises(valid_bytes_128):
+    """
+    Assert that :func:`~ulid.codec.decode_timestamp` raises a :class:`~ValueError` when given
+    a type that cannot be represented as exactly 48 bits.
+    """
+    with pytest.raises(ValueError) as ex:
+       codec.decode_timestamp(valid_bytes_128)
+    assert ex.match(TIMESTAMP_SIZE_EXC_REGEX)
+
+
+def test_decode_randomness_int_returns_randomness_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as an :class:`~int`.
+    """
+    value = int.from_bytes(valid_bytes_80, byteorder='big')
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance.int == value
+
+
+def test_decode_randomness_float_returns_randomness_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as an :class:`~float`.
+    """
+    value = float(int.from_bytes(valid_bytes_80, byteorder='big'))
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance.int == int(value)
+
+
+def test_decode_randomness_str_returns_randomness_instance(valid_bytes_80):
+
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as an :class:`~str`.
+    """
+    value = base32.encode_randomness(valid_bytes_80)
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance.str == value
+
+
+def test_decode_randomness_bytes_returns_randomness_instance(buffer_type, valid_bytes_80):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as an object that supports the buffer protocol.
+    """
+    value = buffer_type(valid_bytes_80)
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance.bytes == value
+
+
+def test_decode_randomness_randomness_returns_randomness_instance(valid_bytes_80):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as a :class:`~ulid.ulid.Randomness`.
+    """
+    value = ulid.Randomness(valid_bytes_80)
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance == value
+
+
+def test_decode_randomness_ulid_returns_randomness_instance(valid_bytes_128):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` returns a new :class:`~ulid.ulid.Randomness` instance
+    from the given random values as a :class:`~ulid.ulid.ULID`.
+    """
+    value = ulid.ULID(valid_bytes_128)
+    instance = codec.decode_randomness(value)
+    assert isinstance(instance, ulid.Randomness)
+    assert instance == value.randomness()
+
+
+def test_decode_randomness_with_unsupported_type_raises(unsupported_type):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` raises a :class:`~ValueError` when given
+    a type it cannot compute a randomness value from.
+    """
+    with pytest.raises(ValueError) as ex:
+        codec.decode_randomness(unsupported_type())
+    assert ex.match(UNSUPPORTED_RANDOMNESS_TYPE_EXC_REGEX)
+
+
+def test_decode_randomness_with_incorrect_size_bytes_raises(valid_bytes_128):
+    """
+    Assert that :func:`~ulid.codec.decode_randomness` raises a :class:`~ValueError` when given
+    a type that cannot be represented as exactly 80 bits.
+    """
+    with pytest.raises(ValueError) as ex:
+        codec.decode_randomness(valid_bytes_128)
+    assert ex.match(RANDOMNESS_SIZE_EXC_REGEX)

--- a/ulid/__init__.py
+++ b/ulid/__init__.py
@@ -9,6 +9,7 @@
 """
 from . import api, ulid
 
+create = api.create
 from_bytes = api.from_bytes
 from_int = api.from_int
 from_randomness = api.from_randomness
@@ -17,6 +18,13 @@ from_timestamp = api.from_timestamp
 from_uuid = api.from_uuid
 new = api.new
 parse = api.parse
+
+MIN_TIMESTAMP = api.MIN_TIMESTAMP
+MAX_TIMESTAMP = api.MAX_TIMESTAMP
+MIN_RANDOMNESS = api.MIN_RANDOMNESS
+MAX_RANDOMNESS = api.MAX_RANDOMNESS
+MIN_ULID = api.MIN_ULID
+MAX_ULID = api.MAX_ULID
 
 Timestamp = ulid.Timestamp
 Randomness = ulid.Randomness

--- a/ulid/base32.py
+++ b/ulid/base32.py
@@ -240,6 +240,7 @@ def decode_ulid(value: str) -> bytes:
     .. note:: This uses an optimized strategy from the `NUlid` project for decoding ULID
         strings specifically and is not meant for arbitrary decoding.
 
+
     :param value: String to decode
     :type value: :class:`~str`
     :return: Value decoded from Base32 string

--- a/ulid/codec.py
+++ b/ulid/codec.py
@@ -1,0 +1,112 @@
+"""
+    ulid/codec
+    ~~~~~~~~~~
+
+    Defines encoding/decoding functions for ULID data representations.
+"""
+import datetime
+import typing
+
+from . import base32, hints, ulid
+
+#: Type hint that defines multiple primitive types that can represent
+#: a Unix timestamp in seconds.
+TimestampPrimitive = typing.Union[hints.Primitive,  # pylint: disable=invalid-name
+                                  datetime.datetime, ulid.Timestamp, ulid.ULID]
+
+
+#: Type hint that defines multiple primitive types that can represent randomness.
+RandomnessPrimitive = typing.Union[hints.Primitive, ulid.Randomness, ulid.ULID]  # pylint: disable=invalid-name
+
+
+def decode_timestamp(timestamp: TimestampPrimitive) -> ulid.Timestamp:
+    """
+    Create a new :class:`~ulid.ulid.ULID` instance using a timestamp value of a supported type.
+
+    The following types are supported for timestamp values:
+
+    * :class:`~datetime.datetime`
+    * :class:`~int`
+    * :class:`~float`
+    * :class:`~str`
+    * :class:`~memoryview`
+    * :class:`~ulid.ulid.Timestamp`
+    * :class:`~ulid.ulid.ULID`
+    * :class:`~bytes`
+    * :class:`~bytearray`
+
+    :param timestamp: Unix timestamp in seconds
+    :type timestamp: See docstring for types
+    :return: ULID using given timestamp and new randomness
+    :rtype: :class:`~ulid.ulid.ULID`
+    :raises ValueError: when the value is an unsupported type
+    :raises ValueError: when the value is a string and cannot be Base32 decoded
+    :raises ValueError: when the value is or was converted to something 48 bits
+    """
+    if isinstance(timestamp, datetime.datetime):
+        timestamp = timestamp.timestamp()
+    if isinstance(timestamp, (int, float)):
+        timestamp = int(timestamp * 1000.0).to_bytes(6, byteorder='big')
+    elif isinstance(timestamp, str):
+        timestamp = base32.decode_timestamp(timestamp)
+    elif isinstance(timestamp, memoryview):
+        timestamp = timestamp.tobytes()
+    elif isinstance(timestamp, ulid.Timestamp):
+        timestamp = timestamp.bytes
+    elif isinstance(timestamp, ulid.ULID):
+        timestamp = timestamp.timestamp().bytes
+
+    if not isinstance(timestamp, (bytes, bytearray)):
+        raise ValueError('Expected datetime, int, float, str, memoryview, Timestamp, ULID, '
+                         'bytes, or bytearray; got {}'.format(type(timestamp).__name__))
+
+    length = len(timestamp)
+    if length != 6:
+        raise ValueError('Expects timestamp to be 48 bits; got {} bytes'.format(length))
+
+    return ulid.Timestamp(timestamp)
+
+
+def decode_randomness(randomness: RandomnessPrimitive) -> ulid.Randomness:
+    """
+    Create a new :class:`~ulid.ulid.Randomness` instance using the given randomness value of a supported type.
+
+    The following types are supported for randomness values:
+
+    * :class:`~int`
+    * :class:`~float`
+    * :class:`~str`
+    * :class:`~memoryview`
+    * :class:`~ulid.ulid.Randomness`
+    * :class:`~ulid.ulid.ULID`
+    * :class:`~bytes`
+    * :class:`~bytearray`
+
+    :param randomness: Random bytes
+    :type randomness: See docstring for types
+    :return: ULID using new timestamp and given randomness
+    :rtype: :class:`~ulid.ulid.ULID`
+    :raises ValueError: when the value is an unsupported type
+    :raises ValueError: when the value is a string and cannot be Base32 decoded
+    :raises ValueError: when the value is or was converted to something 80 bits
+    """
+    if isinstance(randomness, (int, float)):
+        randomness = int(randomness).to_bytes(10, byteorder='big')
+    elif isinstance(randomness, str):
+        randomness = base32.decode_randomness(randomness)
+    elif isinstance(randomness, memoryview):
+        randomness = randomness.tobytes()
+    elif isinstance(randomness, ulid.Randomness):
+        randomness = randomness.bytes
+    elif isinstance(randomness, ulid.ULID):
+        randomness = randomness.randomness().bytes
+
+    if not isinstance(randomness, (bytes, bytearray)):
+        raise ValueError('Expected int, float, str, memoryview, Randomness, ULID, '
+                         'bytes, or bytearray; got {}'.format(type(randomness).__name__))
+
+    length = len(randomness)
+    if length != 10:
+        raise ValueError('Expects randomness to be 80 bits; got {} bytes'.format(length))
+
+    return ulid.Randomness(randomness)

--- a/ulid/hints.py
+++ b/ulid/hints.py
@@ -20,6 +20,10 @@ Buffer = typing.Union[bytes, bytearray, memoryview]  # pylint: disable=invalid-n
 Bytes = bytes  # pylint: disable=invalid-name
 
 
+#: Type hint that is an alias for the built-in :class:`~datetime.datetime` type.
+Datetime = datetime.datetime  # pylint: disable=invalid-name
+
+
 #: Type hint that is an alias for the built-in :class:`~int` type.
 Int = int  # pylint: disable=invalid-name
 
@@ -34,10 +38,6 @@ Primitive = typing.Union[int, float, str, bytes, bytearray, memoryview]  # pylin
 
 #: Type hint that is an alias for the built-in :class:`~str` type.
 Str = str  # pylint: disable=invalid-name
-
-
-#: Type hint that is an alias for the built-in :class:`~datetime.datetime` type.
-Datetime = datetime.datetime  # pylint: disable=invalid-name
 
 
 #: Type hint that is an alias for the built-in :class:`~datetime.datetime` type.


### PR DESCRIPTION
**Status:** WIP

If merged, this adds the `create` function to the API and constants for min/max randomness values.

The goal of this PR is to make it easier to create ULID values for range queries, e.g.

```python
timestamp = time.time()
value = ulid.create(timestamp, ulid.MAX_RANDOMNESS)
```

Fixes #457 

**TODO:**

* [x] Add tests for `create` function
* [x] Add tests for min/max constants
* [x] Add test module for new `codec` module