### PR TITLE
Freeze isort to 4.x on py36

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,5 +13,5 @@ pylint==2.5.3; python_version > '3.4'
 safety==1.9.0
 bandit==1.6.2
 isort==4.2.15; (python_version > '3.0' and python_version < '3.4')  # pyup: ignore
-isort==4.3.21; python_version == '3.5'  # pyup: ignore
-isort==5.2.2; python_version > '3.5'
+isort==4.3.21; (python_version == '3.5' or python_version == '3.6')  # pyup: ignore
+isort==5.2.2; python_version > '3.6'


### PR DESCRIPTION
Revert when https://github.com/timothycrosley/isort/issues/1273 and https://github.com/PyCQA/pylint/pull/3725 are closed.