### PR TITLE
Add MSB validation to raise when timestamp overflows 128 bits

### DIFF
--- a/tests/test_base32.py
+++ b/tests/test_base32.py
@@ -18,6 +18,7 @@ DECODE_STR_LEN_EXC_REGEX = r'^Expects string in lengths of'
 DECODE_ULID_STR_LEN_EXC_REGEX = r'^Expects 26 characters for decoding'
 DECODE_TIMESTAMP_STR_LEN_EXC_REGEX = r'^Expects 10 characters for decoding'
 DECODE_RANDOMNESS_STR_LEN_EXC_REGEX = r'^Expects 16 characters for decoding'
+TIMESTAMP_OVERFLOW_EXC_REGEX = r'Timestamp value too large and will overflow 128-bits. Must be between b"0" and b"7"'
 
 
 @pytest.fixture(scope='session')
@@ -355,3 +356,13 @@ def test_str_to_bytes_raises_on_non_base32_decode_char(ascii_non_base32_str_vali
     with pytest.raises(ValueError) as ex:
         base32.str_to_bytes(ascii_non_base32_str_valid_length, len(ascii_non_base32_str_valid_length))
     ex.match(NON_BASE_32_EXC_REGEX)
+
+
+def test_str_to_bytes_raises_on_timestamp_msb_overflow(invalid_str_10_msb_invalid):
+    """
+    Assert that :func:`~ulid.base32.str_to_bytes` raises a :class:`~ValueError` when given a :class:`~str`
+    instance that includes a valid length timestamp but MSB too large causing an overflow.
+    """
+    with pytest.raises(ValueError) as ex:
+        base32.str_to_bytes(invalid_str_10_msb_invalid, len(invalid_str_10_msb_invalid))
+    ex.match(TIMESTAMP_OVERFLOW_EXC_REGEX)

--- a/ulid/base32.py
+++ b/ulid/base32.py
@@ -366,4 +366,10 @@ def str_to_bytes(value: str, expected_length: int) -> bytes:
         if decoding[byte] > 31:
             raise ValueError('Non-base32 character found: "{}"'.format(chr(byte)))
 
+    # Confirm most significant bit on timestamp value is limited so it can be stored in 128-bits.
+    if length in (10, 26):
+        msb = decoding[encoded[0]]
+        if msb > 7:
+            raise ValueError('Timestamp value too large and will overflow 128-bits. Must be between b"0" and b"7"')
+
     return encoded


### PR DESCRIPTION
**Status:** Ready

If merged, this PR adds validation checks to raise ValueError when decoding ULID values that will overflow 128 bits.

Fixes #468 

```python
>>> import ulid
>>> ulid.parse('7ZZZZZZZZZZZZZZZZZZZZZZZZZ')
<ULID('7ZZZZZZZZZZZZZZZZZZZZZZZZZ')>
>>> ulid.parse('8ZZZZZZZZZZZZZZZZZZZZZZZZZ')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hawker/src/github.com/ahawker/ulid/ulid/api.py", line 85, in parse
    return from_str(value)
  File "/Users/hawker/src/github.com/ahawker/ulid/ulid/api.py", line 190, in from_str
    return ulid.ULID(base32.decode_ulid(value))
  File "/Users/hawker/src/github.com/ahawker/ulid/ulid/base32.py", line 251, in decode_ulid
    encoded = str_to_bytes(value, 26)
  File "/Users/hawker/src/github.com/ahawker/ulid/ulid/base32.py", line 373, in str_to_bytes
    raise ValueError('Timestamp value too large and will overflow 128-bits. Must be between b"0" and b"7"')
ValueError: Timestamp value too large and will overflow 128-bits. Must be between b"0" and b"7"

```