### PR TITLE
Add time providers to ulid.providers.time package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,21 +3,17 @@ language: python
 python:
 - '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 - nightly
 matrix:
   allow_failures:
   - python: nightly
   include:
-  - python: '3.6'
-    env: TOXENV=lint
-  - python: '3.6'
-    env: TOXENV=scan
   - python: '3.7'
-    dist: xenial
-    sudo: true
-  - python: '3.8'
-    dist: xenial
-    sudo: true
+    env: TOXENV=lint
+  - python: '3.7'
+    env: TOXENV=scan
 install: make travis-install
 before_script: make travis-before-script
 script: make travis-script

--- a/tests/test_providers_time_base.py
+++ b/tests/test_providers_time_base.py
@@ -1,0 +1,16 @@
+"""
+    test_providers_time_base
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for the :mod:`~ulid.providers.time.base` module.
+"""
+import inspect
+
+from ulid.providers.time import base
+
+
+def test_provider_is_abstract():
+    """
+    Assert that :class:`~ulid.providers.time.base.Provider` is an abstract class.
+    """
+    assert inspect.isabstract(base.Provider)

--- a/tests/test_providers_time_default.py
+++ b/tests/test_providers_time_default.py
@@ -1,0 +1,66 @@
+"""
+    test_providers_time_default
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for the :mod:`~ulid.providers.time.default` module.
+"""
+import time
+
+import pytest
+
+from ulid.providers.time import base, default
+
+
+@pytest.fixture(scope='function')
+def provider():
+    """
+    Fixture that yields a time provider instance.
+    """
+    return default.Provider()
+
+
+def test_provider_derives_from_base():
+    """
+    Assert that :class:`~ulid.providers.time.default.Provider` derives from :class:`~ulid.providers.time.base.Provider`.
+    """
+    assert issubclass(default.Provider, base.Provider)
+
+
+def test_provider_milliseconds_returns_int(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.default.Provider.milliseconds` returns :class:`~int`.
+    """
+    value = provider.milliseconds()
+    assert isinstance(value, int)
+
+
+def test_provider_microseconds_returns_int(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.default.Provider.microseconds` returns :class:`~int`.
+    """
+    value = provider.microseconds()
+    assert isinstance(value, int)
+
+
+def test_provider_milliseconds_is_unix_epoch(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.default.Provider.milliseconds` returns the current time milliseconds
+    since epoch.
+    """
+    x = int(time.time() * 1000)
+    y = provider.milliseconds()
+    z = int(time.time() * 1000)
+
+    assert x <= y <= z
+
+
+def test_provider_microseconds_is_unix_epoch(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.default.Provider.microseconds` returns the current time microseconds
+    since epoch.
+    """
+    x = int(time.time() * 1000 * 1000)
+    y = provider.microseconds()
+    z = int(time.time() * 1000 * 1000)
+
+    assert x <= y <= z

--- a/tests/test_providers_time_nanosecond.py
+++ b/tests/test_providers_time_nanosecond.py
@@ -1,0 +1,70 @@
+"""
+    test_providers_time_default
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Tests for the :mod:`~ulid.providers.time.default` module.
+"""
+import sys
+import time
+
+import pytest
+
+from ulid.providers.time import base, nanosecond
+
+pytestmark = pytest.mark.skipif(sys.version_info < (3, 7), reason="Requires py3.7+ for time.time_ns()")
+
+
+@pytest.fixture(scope='function')
+def provider():
+    """
+    Fixture that yields a time provider instance.
+    """
+    return nanosecond.Provider()
+
+
+def test_provider_derives_from_base():
+    """
+    Assert that :class:`~ulid.providers.time.nanosecond.Provider` derives
+    from :class:`~ulid.providers.time.base.Provider`.
+    """
+    assert issubclass(nanosecond.Provider, base.Provider)
+
+
+def test_provider_milliseconds_returns_int(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.nanosecond.Provider.milliseconds` returns :class:`~int`.
+    """
+    value = provider.milliseconds()
+    assert isinstance(value, int)
+
+
+def test_provider_microseconds_returns_int(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.nanosecond.Provider.microseconds` returns :class:`~int`.
+    """
+    value = provider.microseconds()
+    assert isinstance(value, int)
+
+
+def test_provider_milliseconds_is_unix_epoch(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.nanosecond.Provider.milliseconds` returns the current time milliseconds
+    since epoch.
+    """
+    x = int(time.time() * 1000)
+    y = provider.milliseconds()
+    z = int(time.time() * 1000)
+
+    assert x <= y <= z
+
+
+def test_provider_microseconds_is_unix_epoch(provider):
+    """
+    Assert that :meth:`~ulid.providers.time.nanosecond.Provider.microseconds` returns the current time microseconds
+    since epoch.
+    """
+    x = int(time.time() * 1000 * 1000)
+    y = provider.microseconds()
+    z = int(time.time() * 1000 * 1000)
+
+    assert x <= y <= z

--- a/ulid/api/api.py
+++ b/ulid/api/api.py
@@ -116,7 +116,7 @@ class Api:
         * :class:`~bytes`
         * :class:`~bytearray`
 
-        :param timestamp: Unix timestamp in seconds
+        :param timestamp: Timestamp in milliseconds
         :type timestamp: See docstring for types
         :return: ULID using given timestamp and new randomness
         :rtype: :class:`~ulid.ulid.ULID`

--- a/ulid/providers/base.py
+++ b/ulid/providers/base.py
@@ -5,14 +5,28 @@
     Contains provider abstract classes.
 """
 import abc
+import typing
 
 from .. import hints
+
+#: Type hint that defines a two item tuple of bytes returned by the provider.
+TimestampRandomnessBytes = typing.Tuple[hints.Bytes, hints.Bytes]  # pylint: disable=invalid-name
 
 
 class Provider(metaclass=abc.ABCMeta):
     """
     Abstract class that defines providers that yield timestamp and randomness values.
     """
+    def new(self) -> TimestampRandomnessBytes:
+        """
+        Create a new timestamp and randomness value.
+
+        :return: Two item tuple containing timestamp and randomness values as :class:`~bytes`.
+        :rtype: :class:`~tuple`
+        """
+        timestamp = self.timestamp()
+        randomness = self.randomness(timestamp)
+        return timestamp, randomness
 
     @abc.abstractmethod
     def timestamp(self) -> hints.Bytes:
@@ -29,6 +43,8 @@ class Provider(metaclass=abc.ABCMeta):
         """
         Create a new randomness value.
 
+        :param timestamp: Timestamp in milliseconds
+        :type timestamp: :class:`~bytes`
         :return: Randomness value in bytes.
         :rtype: :class:`~bytes`
         """

--- a/ulid/providers/base.py
+++ b/ulid/providers/base.py
@@ -5,28 +5,14 @@
     Contains provider abstract classes.
 """
 import abc
-import typing
 
 from .. import hints
-
-#: Type hint that defines a two item tuple of bytes returned by the provider.
-TimestampRandomnessBytes = typing.Tuple[hints.Bytes, hints.Bytes]  # pylint: disable=invalid-name
 
 
 class Provider(metaclass=abc.ABCMeta):
     """
     Abstract class that defines providers that yield timestamp and randomness values.
     """
-    def new(self) -> TimestampRandomnessBytes:
-        """
-        Create a new timestamp and randomness value.
-
-        :return: Two item tuple containing timestamp and randomness values as :class:`~bytes`.
-        :rtype: :class:`~tuple`
-        """
-        timestamp = self.timestamp()
-        randomness = self.randomness(timestamp)
-        return timestamp, randomness
 
     @abc.abstractmethod
     def timestamp(self) -> hints.Bytes:

--- a/ulid/providers/default.py
+++ b/ulid/providers/default.py
@@ -5,10 +5,9 @@
     Contains data provider that creates new randomness values for the same timestamp.
 """
 import os
-import time
 
 from .. import hints
-from . import base
+from . import base, time
 
 
 class Provider(base.Provider):
@@ -23,12 +22,14 @@ class Provider(base.Provider):
         :return: Timestamp value in bytes.
         :rtype: :class:`~bytes`
         """
-        return int(time.time() * 1000).to_bytes(6, byteorder='big')
+        return time.milliseconds().to_bytes(6, byteorder='big')
 
     def randomness(self, timestamp: hints.Bytes) -> hints.Bytes:
         """
         Create a new randomness value.
 
+        :param timestamp: Timestamp in milliseconds
+        :type timestamp: :class:`~bytes`
         :return: Randomness value in bytes.
         :rtype: :class:`~bytes`
         """

--- a/ulid/providers/monotonic.py
+++ b/ulid/providers/monotonic.py
@@ -33,7 +33,7 @@ class Provider(base.Provider):
         """
         Create a new randomness value.
 
-        :param timestamp: Timestamp value in bytes
+        :param timestamp: Timestamp in milliseconds
         :type timestamp: :class:`~bytes`
         :return: Randomness value in bytes.
         :rtype: :class:`~bytes`

--- a/ulid/providers/time/__init__.py
+++ b/ulid/providers/time/__init__.py
@@ -1,0 +1,23 @@
+"""
+    ulid/time
+    ~~~~~~~~~
+
+    Contains functionality for current time providers.
+"""
+import sys
+
+from . import base, default, nanosecond
+
+Provider = base.Provider
+
+# Use :func:`~time.time_ns` when available for highest precision.
+# See https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python for more details.
+if sys.version_info >= (3, 7):
+    PROVIDER = nanosecond.Provider()
+else:
+    PROVIDER = default.Provider()
+
+milliseconds = PROVIDER.milliseconds
+microseconds = PROVIDER.microseconds
+
+__all__ = ['Provider', 'PROVIDER', 'milliseconds', 'microseconds']

--- a/ulid/providers/time/base.py
+++ b/ulid/providers/time/base.py
@@ -1,0 +1,34 @@
+"""
+    ulid/time/base
+    ~~~~~~~~~~~~~~
+
+    Contains time abstract providers.
+"""
+import abc
+
+from ... import hints
+
+
+class Provider(metaclass=abc.ABCMeta):
+    """
+    Abstract class that defines providers for current time values.
+    """
+    @abc.abstractmethod
+    def milliseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in milliseconds.
+
+        :return: Epoch timestamp in milliseconds.
+        :rtype: :class:`~int`
+        """
+        raise NotImplementedError('Method must be implemented by derived class')
+
+    @abc.abstractmethod
+    def microseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in microseconds.
+
+        :return: Epoch timestamp in microseconds.
+        :rtype: :class:`~int`
+        """
+        raise NotImplementedError('Method must be implemented by derived class')

--- a/ulid/providers/time/default.py
+++ b/ulid/providers/time/default.py
@@ -1,0 +1,33 @@
+"""
+    ulid/time/default
+    ~~~~~~~~~~~~~~~~~
+
+    Implements default time provider using :func:`~time.time`.
+"""
+import time
+
+from ... import hints
+from . import base
+
+
+class Provider(base.Provider):
+    """
+    Returns time values from :func:`~time.time`.
+    """
+    def milliseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in milliseconds.
+
+        :return: Epoch timestamp in milliseconds.
+        :rtype: :class:`~int`
+        """
+        return int(time.time() * 1000)
+
+    def microseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in microseconds.
+
+        :return: Epoch timestamp in microseconds.
+        :rtype: :class:`~int`
+        """
+        return int(time.time() * 1000 * 1000)

--- a/ulid/providers/time/nanosecond.py
+++ b/ulid/providers/time/nanosecond.py
@@ -1,0 +1,35 @@
+"""
+    ulid/time/time_ns
+    ~~~~~~~~~~~~~~~~~
+
+    Implements nanosecond time provider using :func:`~time.time_ns`.
+"""
+import time
+
+from ... import hints
+from . import base
+
+
+class Provider(base.Provider):
+    """
+    Returns time values from :func:`~time.time_ns`.
+
+    This class will only work on python 3.7+.
+    """
+    def milliseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in milliseconds.
+
+        :return: Epoch timestamp in milliseconds.
+        :rtype: :class:`~int`
+        """
+        return time.time_ns() // 1000000
+
+    def microseconds(self) -> hints.Int:
+        """
+        Get the current time since unix epoch in microseconds.
+
+        :return: Epoch timestamp in microseconds.
+        :rtype: :class:`~int`
+        """
+        return time.time_ns() // 1000


### PR DESCRIPTION
This adds two provider implementations using the following:

* time.time()
* time.time_ns()

If running on py37+, time.time_ns() will be used as it provides a
more accurate clock resolution according to https://www.python.org/dev/peps/pep-0564/#annex-clocks-resolution-in-python.

**Status:** Ready

<blockquote><img src="https://www.python.org/static/opengraph-icon-200x200.png" width="48" align="right"><div><img src="/static/favicon.ico" height="14"> Python.org</div><div><strong><a href="https://www.python.org/dev/peps/pep-0564/">PEP 564 -- Add new time functions with nanosecond resolution</a></strong></div><div>The official home of the Python Programming Language</div></blockquote>